### PR TITLE
fix: implement middle-click panning for macOS users Resolves issue #38

### DIFF
--- a/src/components/AudioFilePool.vue
+++ b/src/components/AudioFilePool.vue
@@ -11,7 +11,7 @@
 			</div>
 		</div>
 
-		<div class="clips-container">
+		<div class="clips-container" ref="clipsContainer">
 			<div v-for="audioFile in sortedAudioFiles" :key="audioFile.id">
 				<ClipInstance
 					:audiofile="audioFile"
@@ -137,6 +137,43 @@ const sortedAudioFiles = computed(() => {
 	const byDate = (a: AudioFile, b: AudioFile) =>
 		new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
 	return [...owned.sort(byDate), ...foreign.sort(byDate)]
+})
+
+// --- Middle Click Pan Logic (for macOS/Chrome) ---
+const clipsContainerEl = useTemplateRef('clipsContainer')
+
+import { useEventListener } from '@vueuse/core'
+
+useEventListener(clipsContainerEl, 'pointerdown', (e) => {
+	// Only handle middle click (button 1)
+	if (e.button !== 1) return
+
+	const container = clipsContainerEl.value
+	if (!container) return
+
+	// Prevent default browser behavior (like auto-scroll on Windows)
+	e.preventDefault()
+
+	const startX = e.clientX
+	const startScrollLeft = container.scrollLeft
+
+	const target = e.target as HTMLElement
+	target.setPointerCapture(e.pointerId)
+
+	const onMove = (moveEvent: PointerEvent) => {
+		if (!clipsContainerEl.value) return
+		const deltaX = moveEvent.clientX - startX
+		clipsContainerEl.value.scrollLeft = startScrollLeft - deltaX
+	}
+
+	const onUp = (upEvent: PointerEvent) => {
+		target.releasePointerCapture(upEvent.pointerId)
+		stopMove()
+		stopUp()
+	}
+
+	const stopMove = useEventListener(window, 'pointermove', onMove)
+	const stopUp = useEventListener(window, 'pointerup', onUp)
 })
 </script>
 

--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -84,11 +84,11 @@
 			</button>
 			<div style="padding: 0 0.5rem; margin-top: 0.5rem; margin-bottom: 0.5rem">
 				<label
-				for="download-quality"
-				class="txt small dim"
-				style="display: block; margin-bottom: 0.2rem"
+					for="download-quality"
+					class="txt small dim"
+					style="display: block; margin-bottom: 0.2rem"
 				>
-				Download Format
+					Download Format
 				</label>
 				<select
 					id="download-quality"

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -470,6 +470,45 @@ useEventListener(
 	},
 )
 
+// --- Middle Click Pan Logic (for macOS/Chrome) ---
+useEventListener(timelineContainerEl, 'pointerdown', (e) => {
+	// Only handle middle click (button 1)
+	if (e.button !== 1) return
+
+	const container = timelineContainerEl.value
+	if (!container) return
+
+	// Prevent default browser behavior (like auto-scroll on Windows, though we're fixing Mac)
+	e.preventDefault()
+
+	const startX = e.clientX
+	const startY = e.clientY
+	const startScrollLeft = container.scrollLeft
+	const startScrollTop = container.scrollTop
+
+	const target = e.target as HTMLElement
+	target.setPointerCapture(e.pointerId)
+
+	const onMove = (moveEvent: PointerEvent) => {
+		if (!timelineContainerEl.value) return
+		const deltaX = moveEvent.clientX - startX
+		const deltaY = moveEvent.clientY - startY
+
+		// Subtract delta to pan: moving mouse left scrolls right, etc.
+		timelineContainerEl.value.scrollLeft = startScrollLeft - deltaX
+		timelineContainerEl.value.scrollTop = startScrollTop - deltaY
+	}
+
+	const onUp = (upEvent: PointerEvent) => {
+		target.releasePointerCapture(upEvent.pointerId)
+		stopMove()
+		stopUp()
+	}
+
+	const stopMove = useEventListener(window, 'pointermove', onMove)
+	const stopUp = useEventListener(window, 'pointerup', onUp)
+})
+
 const { x: scrollX, y: scrollY } = useScroll(timelineContainerEl)
 const { width: timelineContainerClientWidth } = useElementSize(timelineContainerEl)
 


### PR DESCRIPTION
As requested in issue #38, Mac users were unable to pan the timeline and audio pool using the middle mouse click.

Since macOS does not have a native "auto-scroll" browser feature like Windows, I implemented a custom `pointerdown` (event.button === 1) drag logic. 

Note: I used `e.preventDefault()` which overrides the native Chrome auto-scroll on Windows as well, ensuring a unified, fluid "DAW-like" 1-to-1 dragging experience across all operating systems.

Close #38 