### PR TITLE
fix: center zoom on mouse cursor position

### DIFF
--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -460,9 +460,18 @@ useEventListener(
 	(e) => {
 		if (e.ctrlKey) {
 			e.preventDefault()
+			const container = timelineContainerEl.value!
+			// Beat under cursor before zoom
+			const mouseXInContainer = e.clientX - container.getBoundingClientRect().left
+			const beatUnderCursor = (container.scrollLeft + mouseXInContainer) / pxPerBeat.value
+
 			const sensitivity = 0.05
 			const unclipped = pxPerBeat.value - e.deltaY * sensitivity
-			pxPerBeat.value = Math.max(minPxPerBeat, Math.min(maxPxPerBeat, unclipped))
+			const newPxPerBeat = Math.max(minPxPerBeat, Math.min(maxPxPerBeat, unclipped))
+			pxPerBeat.value = newPxPerBeat
+
+			// Adjust scroll so the same beat stays under the cursor
+			container.scrollLeft = beatUnderCursor * newPxPerBeat - mouseXInContainer
 		}
 	},
 	{


### PR DESCRIPTION
Zoom now stays anchored at the mouse cursor position instead of drifting to the left edge of the viewport.

### Changes
- Compute the beat under the cursor **before** changing `pxPerBeat`
- After updating `pxPerBeat`, adjust `scrollLeft` so that same beat remains under the cursor

Closes #41
