### PR TITLE
feat: clipboard, brush tools, and robust clip interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ideas.md
 
 dev.database
+dev.database.test
 dev.audiofiles
 
 # Cache files

--- a/server/__tests__/clip_batch.test.ts
+++ b/server/__tests__/clip_batch.test.ts
@@ -1,0 +1,187 @@
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import type { Clip } from '~/schema'
+import type { ServerEmitPayload } from '~/events'
+
+type DbModule = typeof import('../database')
+type HistoryModule = typeof import('../history')
+
+let db: DbModule['db']
+let USERS_TABLE: DbModule['USERS_TABLE']
+let history: HistoryModule['history']
+
+const nowIso = () => new Date().toISOString()
+const rid = (prefix: string) => `${prefix}_${Math.random().toString(36).slice(2, 10)}`
+
+async function createFixture() {
+	const userId = rid('user')
+	const providerId = rid('provider')
+	const audioFileId = rid('af')
+	const trackId = rid('track')
+
+	await db.makeNewIfNotExistUserSafe({
+		id: userId,
+		display_name: 'Test User',
+		provider: 'dev',
+		provider_id: providerId,
+		provider_email: `${providerId}@local.test`,
+		roles: ['regular'],
+		color: '#3399ff',
+		banned_at: null,
+		ban_reason: null,
+	})
+
+	await db.saveAudioFile({
+		id: audioFileId,
+		creator_user_id: userId,
+		file_name: `${audioFileId}.wav`,
+		public_url: 'https://example.test/audio.wav',
+		duration: 8,
+		created_at: nowIso(),
+		color: '#88cc88',
+	})
+
+	await db.createTrack({
+		id: trackId,
+		creator_user_id: userId,
+		belongs_to_user_id: null,
+		title: 'Track',
+		gain: 1,
+		created_at: nowIso(),
+	})
+
+	return { userId, audioFileId, trackId }
+}
+
+function makeClip(
+	overrides: Partial<Omit<Clip, 'created_at' | 'creator_display_name'>> = {},
+): Omit<Clip, 'created_at' | 'creator_display_name'> {
+	return {
+		id: rid('clip'),
+		creator_user_id: overrides.creator_user_id ?? 'missing-user',
+		track_id: overrides.track_id ?? 'missing-track',
+		audio_file_id: overrides.audio_file_id ?? 'missing-audio',
+		start_beat: overrides.start_beat ?? 0,
+		end_beat: overrides.end_beat ?? 4,
+		offset_seconds: overrides.offset_seconds ?? 0,
+		gain: overrides.gain ?? 1,
+		muted: overrides.muted ?? false,
+	}
+}
+
+beforeAll(async () => {
+	Bun.env['ENV'] = 'development'
+
+	const databaseMod = await import('../database')
+	const historyMod = await import('../history')
+
+	db = databaseMod.db
+	USERS_TABLE = databaseMod.USERS_TABLE
+	history = historyMod.history
+
+	await db.migrateAndSeedDb()
+})
+
+beforeEach(async () => {
+	// Cascades remove tracks/audiofiles/clips created by previous tests.
+	await db.query(`DELETE FROM ${USERS_TABLE}`)
+})
+
+describe('Clip batch creation', () => {
+	test('createClipsBatch inserts all clips and preserves input order', async () => {
+		const { userId, audioFileId, trackId } = await createFixture()
+
+		const clipA = makeClip({
+			creator_user_id: userId,
+			audio_file_id: audioFileId,
+			track_id: trackId,
+			start_beat: 0,
+			end_beat: 2,
+			offset_seconds: 0.1,
+			gain: 0.8,
+			muted: false,
+		})
+		const clipB = makeClip({
+			creator_user_id: userId,
+			audio_file_id: audioFileId,
+			track_id: trackId,
+			start_beat: 2,
+			end_beat: 4,
+			offset_seconds: 0.2,
+			gain: 1.2,
+			muted: true,
+		})
+
+		const created = await db.createClipsBatch([clipA, clipB])
+
+		expect(created).toHaveLength(2)
+		expect(created.map((c) => c.id)).toEqual([clipA.id, clipB.id])
+		expect(created[0]?.gain).toBe(0.8)
+		expect(created[1]?.muted).toBe(true)
+
+		const storedA = await db.getClip(clipA.id)
+		const storedB = await db.getClip(clipB.id)
+
+		expect(storedA?.id).toBe(clipA.id)
+		expect(storedB?.id).toBe(clipB.id)
+		expect(storedB?.end_beat).toBe(4)
+	})
+})
+
+describe('History undo for batch clip creation', () => {
+	test('undo removes all clips from a CLIP_CREATE_BATCH action', async () => {
+		const { userId, audioFileId, trackId } = await createFixture()
+
+		const clipA = makeClip({
+			creator_user_id: userId,
+			audio_file_id: audioFileId,
+			track_id: trackId,
+			start_beat: 4,
+			end_beat: 6,
+		})
+		const clipB = makeClip({
+			creator_user_id: userId,
+			audio_file_id: audioFileId,
+			track_id: trackId,
+			start_beat: 6,
+			end_beat: 8,
+		})
+
+		const created = await db.createClipsBatch([clipA, clipB])
+
+		history.push({
+			type: 'CLIP_CREATE_BATCH',
+			data: {
+				payload: {
+					clips: [clipA, clipB].map((clip) => ({
+						start_beat: clip.start_beat,
+						end_beat: clip.end_beat,
+						audio_file_id: clip.audio_file_id,
+						track_id: clip.track_id,
+						offset_seconds: clip.offset_seconds,
+						gain: clip.gain,
+						muted: clip.muted,
+					})),
+					ids: created.map((clip) => clip.id),
+				},
+				inverse: created.map((clip) => clip.id),
+			},
+			userId,
+		})
+
+		const emittedDeletes: Array<ServerEmitPayload<'clip:delete'>> = []
+
+		const result = await history.undo(userId, (event, payload) => {
+			if (event === 'clip:delete' && typeof payload === 'string') {
+				emittedDeletes.push(payload)
+			}
+		})
+
+		expect(result).toEqual({ success: true })
+		expect(emittedDeletes).toHaveLength(2)
+		expect(emittedDeletes).toEqual(created.map((clip) => clip.id))
+
+		for (const clip of created) {
+			expect(await db.getClip(clip.id)).toBeNull()
+		}
+	})
+})

--- a/server/__tests__/clip_batch.test.ts
+++ b/server/__tests__/clip_batch.test.ts
@@ -70,6 +70,7 @@ function makeClip(
 
 beforeAll(async () => {
 	Bun.env['ENV'] = 'development'
+	Bun.env['DEV_DATABASE_FOLDER'] = 'dev.database.test'
 
 	const databaseMod = await import('../database')
 	const historyMod = await import('../history')

--- a/server/__tests__/clip_batch.test.ts
+++ b/server/__tests__/clip_batch.test.ts
@@ -69,8 +69,7 @@ function makeClip(
 }
 
 beforeAll(async () => {
-	Bun.env['ENV'] = 'development'
-	Bun.env['DEV_DATABASE_FOLDER'] = 'dev.database.test'
+	Bun.env['ENV'] = 'test'
 
 	const databaseMod = await import('../database')
 	const historyMod = await import('../history')

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -5,3 +5,4 @@ export const MAX_UPLOAD_FILE_SIZE_BYTES = 134217728 as const // 128MB -> 128 * 1
 export const DEV_FILE_SERVE_URL = '/api/dev-serve-files/' as const
 
 export const DEV_DATABASE_FOLDER = 'dev.database' as const
+export const TEST_DATABASE_FOLDER = 'dev.database.test' as const

--- a/server/database.ts
+++ b/server/database.ts
@@ -56,7 +56,8 @@ if (!IN_DEV_MODE) {
 } else {
 	print.db('Using PGlite')
 
-	const dataDir = join(import.meta.dir, '..', DEV_DATABASE_FOLDER)
+	const devDatabaseFolder = Bun.env['DEV_DATABASE_FOLDER'] || DEV_DATABASE_FOLDER
+	const dataDir = join(import.meta.dir, '..', devDatabaseFolder)
 	const client = new PGlite(dataDir)
 
 	queryFn = async (query, params = []) => {

--- a/server/database.ts
+++ b/server/database.ts
@@ -83,6 +83,7 @@ export const db = {
 	getTrack,
 	updateTrack,
 	createClip,
+	createClipsBatch,
 	getClips,
 	getClip,
 	deleteClip,
@@ -240,6 +241,98 @@ async function createClip(clip: Omit<Clip, 'created_at' | 'creator_display_name'
 	const result = rows[0]!
 
 	return result
+}
+
+async function createClipsBatch(
+	clipsToCreate: Array<Omit<Clip, 'created_at' | 'creator_display_name'>>,
+): Promise<Clip[]> {
+	if (clipsToCreate.length === 0) return []
+
+	const params: Array<string | number | boolean> = []
+	const valuesSql: string[] = []
+
+	for (let i = 0; i < clipsToCreate.length; i++) {
+		const clip = clipsToCreate[i]!
+		const base = i * 9
+
+		valuesSql.push(
+			`(${i + 1}, $${base + 1}::TEXT, $${base + 2}::TEXT, $${base + 3}::TEXT, $${base + 4}::TEXT, $${base + 5}::DOUBLE PRECISION, $${base + 6}::DOUBLE PRECISION, $${base + 7}::DOUBLE PRECISION, $${base + 8}::DOUBLE PRECISION, $${base + 9}::BOOLEAN)`,
+		)
+
+		params.push(
+			clip.id,
+			clip.creator_user_id,
+			clip.track_id,
+			clip.audio_file_id,
+			clip.end_beat,
+			clip.start_beat,
+			clip.gain,
+			clip.offset_seconds,
+			clip.muted,
+		)
+	}
+
+	const rows = await queryFn<Clip>(
+		`
+			WITH input_rows (
+				ord,
+				id,
+				creator_user_id,
+				track_id,
+				audio_file_id,
+				end_beat,
+				start_beat,
+				gain,
+				offset_seconds,
+				muted
+			) AS (
+				VALUES ${valuesSql.join(',\n')}
+			),
+			inserted AS (
+				INSERT INTO ${CLIPS_TABLE} (
+					id,
+					creator_user_id,
+					track_id,
+					audio_file_id,
+					end_beat,
+					start_beat,
+					gain,
+					offset_seconds,
+					muted
+				)
+				SELECT
+					id,
+					creator_user_id,
+					track_id,
+					audio_file_id,
+					end_beat,
+					start_beat,
+					gain,
+					offset_seconds,
+					muted
+				FROM input_rows
+				ORDER BY ord
+				RETURNING *
+			)
+			SELECT
+				inserted.*,
+				users.display_name AS creator_display_name
+			FROM inserted
+			JOIN input_rows ON input_rows.id = inserted.id
+			LEFT JOIN ${USERS_TABLE} AS users
+				ON inserted.creator_user_id = users.id
+			ORDER BY input_rows.ord
+		`,
+		params,
+	)
+
+	if (rows.length !== clipsToCreate.length) {
+		throw new Error(
+			`Failed to create all clips in batch (${rows.length}/${clipsToCreate.length})`,
+		)
+	}
+
+	return rows
 }
 
 async function getClips(): Promise<Clip[]> {

--- a/server/database.ts
+++ b/server/database.ts
@@ -15,7 +15,7 @@ import {
 import { migrations } from './migrations'
 import { print, randomSafeHexColor } from './utils'
 import { nanoid } from 'nanoid'
-import { DEV_DATABASE_FOLDER } from './constants'
+import { DEV_DATABASE_FOLDER, TEST_DATABASE_FOLDER } from './constants'
 import z from 'zod'
 
 // todo: update all the hanlders to not return safely when they
@@ -29,7 +29,7 @@ const SessionSchema = z.object({
 
 export type Session = z.output<typeof SessionSchema>
 
-const IN_DEV_MODE = Bun.env['ENV'] === 'development'
+const IN_DEV_MODE = Bun.env['ENV'] === 'development' || Bun.env['ENV'] === 'test'
 export type QueryHandler = <T = any>(query: string, params?: any[]) => Promise<T[]>
 
 let queryFn: QueryHandler
@@ -56,7 +56,7 @@ if (!IN_DEV_MODE) {
 } else {
 	print.db('Using PGlite')
 
-	const devDatabaseFolder = Bun.env['DEV_DATABASE_FOLDER'] || DEV_DATABASE_FOLDER
+	const devDatabaseFolder = Bun.env['ENV'] === 'test' ? TEST_DATABASE_FOLDER : DEV_DATABASE_FOLDER
 	const dataDir = join(import.meta.dir, '..', devDatabaseFolder)
 	const client = new PGlite(dataDir)
 

--- a/server/database.ts
+++ b/server/database.ts
@@ -206,13 +206,14 @@ async function createClip(clip: Omit<Clip, 'created_at' | 'creator_display_name'
 		start_beat,
 		gain,
 		offset_seconds,
+		muted,
 	} = clip
 
 	const rows = await queryFn<Clip>(
 		`
 			WITH inserted AS (
-				INSERT INTO ${CLIPS_TABLE} (id, creator_user_id, track_id, audio_file_id, end_beat, start_beat, gain, offset_seconds) 
-				VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+				INSERT INTO ${CLIPS_TABLE} (id, creator_user_id, track_id, audio_file_id, end_beat, start_beat, gain, offset_seconds, muted) 
+				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 				RETURNING *
 			)
 			SELECT 
@@ -222,7 +223,17 @@ async function createClip(clip: Omit<Clip, 'created_at' | 'creator_display_name'
 			LEFT JOIN ${USERS_TABLE} AS users
 				ON inserted.creator_user_id = users.id
 		`,
-		[id, creator_user_id, track_id, audio_file_id, end_beat, start_beat, gain, offset_seconds],
+		[
+			id,
+			creator_user_id,
+			track_id,
+			audio_file_id,
+			end_beat,
+			start_beat,
+			gain,
+			offset_seconds,
+			muted,
+		],
 	)
 
 	if (!rows.length) throw new Error('Failed to create clip')

--- a/server/history.ts
+++ b/server/history.ts
@@ -10,6 +10,10 @@ type HistoryEventMap = {
 		payload: ClientRequestPayload<'get:clip:create'> & { id: Clip['id'] }
 		inverse: ServerEmitPayload<'clip:delete'>
 	}
+	CLIP_CREATE_BATCH: {
+		payload: ClientRequestPayload<'get:clips:create:batch'> & { ids: Clip['id'][] }
+		inverse: ServerEmitPayload<'clip:delete'>[]
+	}
 	CLIP_DELETE: {
 		payload: ClientRequestPayload<'get:clip:delete'>
 		inverse: ServerEmitPayload<'clip:create'>
@@ -108,6 +112,33 @@ class HistoryManager {
 						}
 					}
 
+					break
+				}
+
+				case 'CLIP_CREATE_BATCH': {
+					const clipIds = action.data.inverse
+
+					for (const clipId of clipIds) {
+						let current: Awaited<ReturnType<typeof db.getClip>>
+
+						try {
+							current = await db.getClip(clipId)
+						} catch {
+							return { success: false, error: 'Failed to retrieve clip status.' }
+						}
+
+						// Best-effort idempotency: if already gone, just continue.
+						if (!current) continue
+
+						try {
+							await db.deleteClip(clipId)
+							socketBroadcast('clip:delete', clipId)
+						} catch {
+							return { success: false, error: 'Failed to delete pasted clips.' }
+						}
+					}
+
+					processed = true
 					break
 				}
 

--- a/server/migrations.ts
+++ b/server/migrations.ts
@@ -68,6 +68,7 @@ export const migrations: Migration[] = [
                     end_beat DOUBLE PRECISION NOT NULL,
                     offset_seconds DOUBLE PRECISION NOT NULL,
                     gain DOUBLE PRECISION NOT NULL,
+                    muted BOOLEAN NOT NULL DEFAULT FALSE,
                     created_at TIMESTAMPTZ DEFAULT NOW()
                 )`)
 
@@ -97,6 +98,26 @@ export const migrations: Migration[] = [
 			await queryFn(`
                 ALTER TABLE ${USERS_TABLE}
                 ADD COLUMN IF NOT EXISTS download_quality TEXT NOT NULL DEFAULT 'wav'
+            `)
+		},
+	},
+	{
+		id: 4,
+		name: 'add_muted_clips',
+		func: async (queryFn) => {
+			await queryFn(`
+                ALTER TABLE ${CLIPS_TABLE}
+                ADD COLUMN IF NOT EXISTS muted BOOLEAN NOT NULL DEFAULT FALSE
+            `)
+		},
+	},
+	{
+		id: 5,
+		name: 'ensure_muted_clips_column',
+		func: async (queryFn) => {
+			await queryFn(`
+                ALTER TABLE ${CLIPS_TABLE}
+                ADD COLUMN IF NOT EXISTS muted BOOLEAN NOT NULL DEFAULT FALSE
             `)
 		},
 	},

--- a/server/migrations.ts
+++ b/server/migrations.ts
@@ -111,14 +111,4 @@ export const migrations: Migration[] = [
             `)
 		},
 	},
-	{
-		id: 5,
-		name: 'ensure_muted_clips_column',
-		func: async (queryFn) => {
-			await queryFn(`
-                ALTER TABLE ${CLIPS_TABLE}
-                ADD COLUMN IF NOT EXISTS muted BOOLEAN NOT NULL DEFAULT FALSE
-            `)
-		},
-	},
 ]

--- a/server/server.ts
+++ b/server/server.ts
@@ -469,13 +469,11 @@ io.on('connection', async (socket) => {
 
 			const { clips: inputClips } = data
 
-			const createdClips: Clip[] = []
 			try {
-				for (const input of inputClips) {
-					const newClip: Omit<Clip, 'created_at'> = {
+				const newClips: Array<Omit<Clip, 'created_at' | 'creator_display_name'>> =
+					inputClips.map((input) => ({
 						id: nanoid(),
 						creator_user_id: user.id,
-						creator_display_name: user.display_name,
 						start_beat: input.start_beat,
 						end_beat: input.end_beat,
 						audio_file_id: input.audio_file_id,
@@ -483,11 +481,8 @@ io.on('connection', async (socket) => {
 						offset_seconds: input.offset_seconds ?? 0,
 						muted: input.muted ?? false,
 						track_id: input.track_id,
-					}
-
-					const clip = await db.createClip(newClip)
-					createdClips.push(clip)
-				}
+					}))
+				const createdClips = await db.createClipsBatch(newClips)
 
 				callback({
 					success: true,
@@ -510,15 +505,6 @@ io.on('connection', async (socket) => {
 					userId: user.id,
 				})
 			} catch (err) {
-				// Best effort rollback for partial writes in case one insert fails.
-				for (const clip of createdClips) {
-					try {
-						await db.deleteClip(clip.id)
-					} catch {
-						// ignore rollback errors, original error below is more relevant
-					}
-				}
-
 				const error = err instanceof Error ? err.message : 'Unknown error'
 				callback({
 					success: false,

--- a/server/server.ts
+++ b/server/server.ts
@@ -409,7 +409,8 @@ io.on('connection', async (socket) => {
 				})
 				return
 			}
-			const { start_beat, end_beat, audio_file_id, track_id, offset_seconds, gain } = data
+			const { start_beat, end_beat, audio_file_id, track_id, offset_seconds, gain, muted } =
+				data
 
 			const newClip: Omit<Clip, 'created_at'> = {
 				id: nanoid(),
@@ -420,6 +421,7 @@ io.on('connection', async (socket) => {
 				audio_file_id,
 				gain: gain ?? DEFAULT_GAIN,
 				offset_seconds: offset_seconds ?? 0,
+				muted: muted ?? false,
 				track_id,
 			}
 
@@ -442,6 +444,81 @@ io.on('connection', async (socket) => {
 					userId: user.id,
 				})
 			} catch (err) {
+				const error = err instanceof Error ? err.message : 'Unknown error'
+				callback({
+					success: false,
+					error: {
+						status: 'SERVER_ERROR',
+						message: `Database error: ${error}`,
+					},
+				})
+			}
+		})
+
+		socket.on('get:clips:create:batch', async (data, callback) => {
+			if (user.banned_at) {
+				callback({
+					success: false,
+					error: {
+						status: 'UNAUTHORIZED',
+						message: 'You are banned and cannot create clips.',
+					},
+				})
+				return
+			}
+
+			const { clips: inputClips } = data
+
+			const createdClips: Clip[] = []
+			try {
+				for (const input of inputClips) {
+					const newClip: Omit<Clip, 'created_at'> = {
+						id: nanoid(),
+						creator_user_id: user.id,
+						creator_display_name: user.display_name,
+						start_beat: input.start_beat,
+						end_beat: input.end_beat,
+						audio_file_id: input.audio_file_id,
+						gain: input.gain ?? DEFAULT_GAIN,
+						offset_seconds: input.offset_seconds ?? 0,
+						muted: input.muted ?? false,
+						track_id: input.track_id,
+					}
+
+					const clip = await db.createClip(newClip)
+					createdClips.push(clip)
+				}
+
+				callback({
+					success: true,
+					data: createdClips,
+				})
+
+				for (const clip of createdClips) {
+					socket.broadcast.emit('clip:create', clip)
+				}
+
+				history.push({
+					type: 'CLIP_CREATE_BATCH',
+					data: {
+						payload: {
+							clips: inputClips,
+							ids: createdClips.map((clip) => clip.id),
+						},
+						inverse: createdClips.map((clip) => clip.id),
+					},
+					userId: user.id,
+				})
+			} catch (err) {
+				// Best effort rollback for partial writes in case one insert fails.
+				for (const clip of createdClips) {
+					try {
+						await db.deleteClip(clip.id)
+					} catch {
+						// ignore rollback errors, original error below is more relevant
+					}
+				}
+
 				const error = err instanceof Error ? err.message : 'Unknown error'
 				callback({
 					success: false,

--- a/shared/events.ts
+++ b/shared/events.ts
@@ -179,8 +179,27 @@ export const EVENTS = Object.freeze({
 				track_id: z.string(),
 				offset_seconds: z.number().optional(),
 				gain: z.number().optional(),
+				muted: z.boolean().optional(),
 			}),
 			res: ClientClipSchema,
+		}),
+		'get:clips:create:batch': defineRequest({
+			req: z.object({
+				clips: z
+					.array(
+						z.object({
+							start_beat: z.number(),
+							end_beat: z.number(),
+							audio_file_id: z.string(),
+							track_id: z.string(),
+							offset_seconds: z.number().optional(),
+							gain: z.number().optional(),
+							muted: z.boolean().optional(),
+						}),
+					)
+					.min(1),
+			}),
+			res: z.array(ClientClipSchema),
 		}),
 		'get:clip:delete': defineRequest({
 			req: ClientClipSchema.pick({ id: true }),

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -31,6 +31,7 @@ export const ServerClipSchema = z.object({
 	end_beat: z.number(),
 	offset_seconds: z.number(),
 	gain: z.number(),
+	muted: z.boolean(),
 	created_at: z.iso.datetime({ offset: true }),
 })
 

--- a/src/audioEngine.ts
+++ b/src/audioEngine.ts
@@ -63,7 +63,7 @@ export const loopRangeBeats = computed(() => {
 })
 
 function getClipHash(clip: Clip): string {
-	return `${clip.start_beat}:${clip.end_beat}:${clip.offset_seconds}:${clip.audio_file_id}:${clip.track_id}:${clip.gain}:${clip.muted}`
+	return `${clip.start_beat}:${clip.end_beat}:${clip.offset_seconds}:${clip.audio_file_id}:${clip.track_id}:${clip.muted}`
 }
 
 function stopSource(sourceWrapper: { source: AudioBufferSourceNode; gainNode: GainNode }) {
@@ -163,6 +163,12 @@ function reconcileActiveSources() {
 		if (currentHash !== wrapper.hash) {
 			stopSource(wrapper)
 			activeSources.delete(key)
+			continue
+		}
+
+		// Keep active source and smooth gain changes instead of recreating source.
+		if (wrapper.gainNode.gain.value !== clip.gain) {
+			wrapper.gainNode.gain.setTargetAtTime(clip.gain, audioContext.currentTime, 0.02)
 		}
 	}
 

--- a/src/audioEngine.ts
+++ b/src/audioEngine.ts
@@ -9,6 +9,8 @@ const inDev = import.meta.env.MODE === 'development'
 export const audioContext = new AudioContext()
 const masterGain = audioContext.createGain()
 masterGain.connect(audioContext.destination)
+let previewSource: AudioBufferSourceNode | null = null
+let previewGain: GainNode | null = null
 
 const trackGainNodes = new Map<string, GainNode>()
 const trackAnalysers = new Map<string, AnalyserNode>()
@@ -61,7 +63,7 @@ export const loopRangeBeats = computed(() => {
 })
 
 function getClipHash(clip: Clip): string {
-	return `${clip.start_beat}:${clip.end_beat}:${clip.offset_seconds}:${clip.audio_file_id}:${clip.track_id}:${clip.gain}`
+	return `${clip.start_beat}:${clip.end_beat}:${clip.offset_seconds}:${clip.audio_file_id}:${clip.track_id}:${clip.gain}:${clip.muted}`
 }
 
 function stopSource(sourceWrapper: { source: AudioBufferSourceNode; gainNode: GainNode }) {
@@ -72,6 +74,69 @@ function stopSource(sourceWrapper: { source: AudioBufferSourceNode; gainNode: Ga
 	} catch (e) {
 		if (inDev) console.error(e)
 	}
+}
+
+export function stopAudioPreview() {
+	if (!previewSource) return
+
+	try {
+		previewSource.stop()
+	} catch (e) {
+		if (inDev) console.error(e)
+	}
+
+	previewSource.disconnect()
+	previewGain?.disconnect()
+	previewSource = null
+	previewGain = null
+}
+
+export async function previewAudioFile(
+	audioFileId: string,
+	opts?: { offsetSeconds?: number; durationSeconds?: number; gain?: number },
+) {
+	const buffer = audioBuffers.get(audioFileId)
+	if (!buffer) return false
+
+	if (audioContext.state === 'suspended') {
+		await audioContext.resume()
+	}
+
+	stopAudioPreview()
+
+	const offsetSeconds = Math.max(0, opts?.offsetSeconds ?? 0)
+	const maxDuration = Math.max(0, buffer.duration - offsetSeconds)
+	if (maxDuration <= 0) return false
+
+	const durationSeconds = Math.min(
+		maxDuration,
+		Math.max(0.01, opts?.durationSeconds ?? maxDuration),
+	)
+	const gain = Math.max(0, opts?.gain ?? 1)
+
+	const source = audioContext.createBufferSource()
+	const previewGainNode = audioContext.createGain()
+
+	source.buffer = buffer
+	previewGainNode.gain.value = gain
+	source.connect(previewGainNode)
+	// Preview should still be audible when transport is stopped and masterGain is faded out.
+	previewGainNode.connect(audioContext.destination)
+
+	previewSource = source
+	previewGain = previewGainNode
+
+	source.start(audioContext.currentTime, offsetSeconds, durationSeconds)
+
+	source.onended = () => {
+		if (previewSource !== source) return
+		source.disconnect()
+		previewGainNode.disconnect()
+		previewSource = null
+		previewGain = null
+	}
+
+	return true
 }
 
 function reconcileActiveSources() {
@@ -102,6 +167,7 @@ function reconcileActiveSources() {
 	}
 
 	for (const clip of clips.values()) {
+		if (clip.muted) continue
 		const clipStartSeconds = beats_to_sec(clip.start_beat)
 		const clipEndSeconds = beats_to_sec(clip.end_beat)
 
@@ -357,6 +423,8 @@ function scheduleClipSource(
 	iteration: number,
 	maxEndSec?: number,
 ) {
+	if (clip.muted) return
+
 	const buffer = audioBuffers.get(clip.audio_file_id)
 	const trackGainNode = trackGainNodes.get(clip.track_id)
 

--- a/src/components/AudioFilePool.vue
+++ b/src/components/AudioFilePool.vue
@@ -8,6 +8,15 @@
 			<div style="display: flex; gap: 1rem" class="dim small">
 				<p>Total Files: {{ audiofiles.size }}</p>
 				<p>Total Clips: {{ clips.size }}</p>
+				<button
+					class="no-select default-button preview-toggle"
+					:class="{ secondary: !audioPoolPreviewOnClick }"
+					@click="audioPoolPreviewOnClick = !audioPoolPreviewOnClick"
+				>
+					<Check v-if="audioPoolPreviewOnClick" :size="14" />
+					<X v-else :size="14" />
+					<span>Preview Sample</span>
+				</button>
 			</div>
 		</div>
 
@@ -60,13 +69,20 @@
 </template>
 
 <script setup lang="ts">
-import { audiofiles, clips, user, AUDIO_POOL_WIDTH, audioFilePoolHeightPx } from '@/state'
+import {
+	audiofiles,
+	clips,
+	user,
+	AUDIO_POOL_WIDTH,
+	audioFilePoolHeightPx,
+	audioPoolPreviewOnClick,
+} from '@/state'
 import UploadButton from '@/components/UploadButton.vue'
 import { computed, useTemplateRef, watchEffect } from 'vue'
 import type { AudioFile } from '@/types'
 import ClipInstance from '@/components/ClipInstance.vue'
 import { useDropZone, useElementSize } from '@vueuse/core'
-import { File } from 'lucide-vue-next'
+import { Check, File, X } from 'lucide-vue-next'
 import { audioMimeTypes } from '~/constants'
 import { optimisticAudioCreateUpload } from '@/utils/uploadAudio'
 import { useGlobalProgress } from '@/composables/useGlobalProgress'
@@ -222,5 +238,15 @@ const sortedAudioFiles = computed(() => {
 .clips-container::-webkit-scrollbar {
 	display: none;
 	/* Chrome, Safari, Opera */
+}
+
+.preview-toggle {
+	height: 2.1rem;
+	padding: 0 0.8rem;
+	gap: 0.4rem;
+}
+
+.preview-toggle.secondary {
+	opacity: 0.75;
 }
 </style>

--- a/src/components/ClipInstance.vue
+++ b/src/components/ClipInstance.vue
@@ -5,13 +5,15 @@
 			waveformsDrawn,
 			canvasStyles,
 			props.audiofile.file_name,
+			props.clip?.muted,
 			isHovered,
 			isSelected,
 			!!dragSession,
 		]"
 		ref="clipWrapper"
 		class="outmostClipWrapper clip"
-		:class="{ selected: isSelected, 'is-dragging': !!dragSession }"
+		:data-clip-id="props.clip?.id"
+		:class="{ selected: isSelected, muted: !!props.clip?.muted, 'is-dragging': !!dragSession }"
 		:style="wrapperStyles"
 		@contextmenu.prevent="rip"
 	>
@@ -60,13 +62,21 @@ import {
 import {
 	TOTAL_BEATS,
 	altKeyPressed,
+	shiftKeyPressed,
 	clips,
 	controlKeyPressed,
 	dragFromPoolState,
 	pixelRatio,
-	rightMouseButtonPressedOnTimeline,
 	user,
 	selectedClipIds,
+	activeTool,
+	brushAudioFileId,
+	brushSourceClip,
+	multiDragState,
+	tracks,
+	pxTrackHeight,
+	audioPoolPreviewOnClick,
+	cloneDragPreview,
 } from '@/state'
 import type { Clip } from '~/schema'
 import {
@@ -89,6 +99,8 @@ import type { AudioFile } from '@/types'
 import { Trash2 } from 'lucide-vue-next'
 import { deleteAudio } from '@/socket/eventHandlers/audiofile_delete'
 import { useConsole } from '@/composables/useConsole'
+import { nanoid } from 'nanoid'
+import { previewAudioFile } from '@/audioEngine'
 
 const { userLog } = useConsole()
 
@@ -137,17 +149,198 @@ const outerClipCanvasStyles = computed((): CSSProperties => {
 async function rip() {
 	if (!props.clip) return
 	if (user.value?.banned_at) return
-	const res = await socket.emitWithAck('get:clip:delete', { id: props.clip.id })
+	const clipId = props.clip.id
+	const res = await socket.emitWithAck('get:clip:delete', { id: clipId })
 
 	if (res.success) {
 		clips.delete(res.data.id)
+		selectedClipIds.delete(res.data.id)
+		return
+	}
+
+	const message = res.error?.message ?? ''
+	// Idempotent behavior for races: clip may already be deleted on server.
+	if (message.includes('Failed to delete clip')) {
+		clips.delete(clipId)
+		selectedClipIds.delete(clipId)
 	}
 }
 
-const isSelected = computed(() => {
-	if (!props.clip) return false
-	return selectedClipIds.has(props.clip.id)
-})
+async function sliceClipAtPointer(clientX: number) {
+	if (!props.clip || !wrapperEl.value) return
+	if (user.value?.banned_at) return
+
+	const clip = clips.get(props.clip.id)
+	if (!clip) return
+
+	// Let the optimistic create flow finish first for temp clips.
+	if (clip.id.startsWith('__temp__')) return
+
+	const rect = wrapperEl.value.getBoundingClientRect()
+	const localX = clientX - rect.left
+	const rawCutBeat = clip.start_beat + px_to_beats(localX)
+	let cutBeat = altKeyPressed.value ? rawCutBeat : quantize_beats(rawCutBeat)
+
+	cutBeat = Math.max(clip.start_beat, Math.min(clip.end_beat, cutBeat))
+	const epsilon = 0.0001
+	if (cutBeat <= clip.start_beat + epsilon || cutBeat >= clip.end_beat - epsilon) return
+
+	const originalStartBeat = clip.start_beat
+	const originalEndBeat = clip.end_beat
+	const originalOffsetSeconds = clip.offset_seconds
+	const originalTrackId = clip.track_id
+	const secondOffsetSeconds = originalOffsetSeconds + beats_to_sec(cutBeat - originalStartBeat)
+
+	// Optimistic split preview.
+	clip.end_beat = cutBeat
+	const tempSecondId = `__temp__${nanoid()}`
+	const tempSecondClip: Clip = {
+		...clip,
+		id: tempSecondId,
+		start_beat: cutBeat,
+		end_beat: originalEndBeat,
+		offset_seconds: secondOffsetSeconds,
+		created_at: new Date().toISOString(),
+	}
+	clips.set(tempSecondId, tempSecondClip)
+
+	const updateRes = await socket.emitWithAck('get:clip:update', {
+		id: clip.id,
+		changes: {
+			end_beat: cutBeat,
+		},
+	})
+
+	if (!updateRes.success) {
+		clip.end_beat = originalEndBeat
+		clips.delete(tempSecondId)
+		userLog('SYSTEM', `Failed to slice clip: ${updateRes.error.message}`, {
+			textColor: 'red',
+		})
+		return
+	}
+
+	const persistedCutBeat = updateRes.data['end_beat'] ?? cutBeat
+	clip.end_beat = persistedCutBeat
+	const persistedSecondOffset =
+		originalOffsetSeconds + beats_to_sec(persistedCutBeat - originalStartBeat)
+
+	const createRes = await socket.emitWithAck('get:clip:create', {
+		audio_file_id: clip.audio_file_id,
+		track_id: originalTrackId,
+		start_beat: persistedCutBeat,
+		end_beat: originalEndBeat,
+		offset_seconds: persistedSecondOffset,
+		gain: clip.gain,
+		muted: clip.muted,
+	})
+
+	if (createRes.success) {
+		clips.delete(tempSecondId)
+		clips.set(createRes.data.id, createRes.data)
+		selectedClipIds.clear()
+		return
+	}
+
+	// Roll back split if second half creation failed.
+	clips.delete(tempSecondId)
+	const restoreRes = await socket.emitWithAck('get:clip:update', {
+		id: clip.id,
+		changes: {
+			end_beat: originalEndBeat,
+		},
+	})
+
+	if (restoreRes.success) {
+		clip.end_beat = restoreRes.data['end_beat'] ?? originalEndBeat
+	} else {
+		clip.end_beat = originalEndBeat
+	}
+
+	userLog('SYSTEM', `Failed to slice clip: ${createRes.error.message}`, {
+		textColor: 'red',
+	})
+}
+
+async function createClipClone(
+	sourceClip: Clip,
+	opts: { startBeat: number; endBeat: number; trackId: string },
+) {
+	if (user.value?.banned_at) return
+	if (sourceClip.id.startsWith('__temp__')) return
+
+	const tempId = `__temp__${nanoid()}`
+	const tempClone: Clip = {
+		...sourceClip,
+		id: tempId,
+		track_id: opts.trackId,
+		start_beat: opts.startBeat,
+		end_beat: opts.endBeat,
+		creator_user_id: user.value?.id ?? sourceClip.creator_user_id,
+		creator_display_name: user.value?.display_name ?? sourceClip.creator_display_name,
+		created_at: new Date().toISOString(),
+	}
+
+	clips.set(tempId, tempClone)
+
+	const res = await socket.emitWithAck('get:clip:create', {
+		audio_file_id: sourceClip.audio_file_id,
+		track_id: opts.trackId,
+		start_beat: opts.startBeat,
+		end_beat: opts.endBeat,
+		offset_seconds: sourceClip.offset_seconds,
+		gain: sourceClip.gain,
+		muted: sourceClip.muted,
+	})
+
+	if (res.success) {
+		clips.delete(tempId)
+		clips.set(res.data.id, res.data)
+		return
+	}
+
+	clips.delete(tempId)
+	userLog('SYSTEM', `Failed to clone clip: ${res.error.message}`, {
+		textColor: 'red',
+	})
+}
+
+type ClipMoveSnapshot = {
+	startBeat: number
+	endBeat: number
+	trackId: string
+}
+
+function rollbackMoveIfUnchanged(
+	clipId: string,
+	expected: ClipMoveSnapshot,
+	previous: ClipMoveSnapshot,
+) {
+	const current = clips.get(clipId)
+	if (!current) return
+
+	if (
+		current.start_beat !== expected.startBeat ||
+		current.end_beat !== expected.endBeat ||
+		current.track_id !== expected.trackId
+	) {
+		return
+	}
+
+	current.start_beat = previous.startBeat
+	current.end_beat = previous.endBeat
+	current.track_id = previous.trackId
+}
+
+function setBrushSourceFromClip(clip: Clip) {
+	brushAudioFileId.value = clip.audio_file_id
+	brushSourceClip.value = {
+		audioFileId: clip.audio_file_id,
+		lengthBeats: Math.max(0.01, clip.end_beat - clip.start_beat),
+		offsetSeconds: clip.offset_seconds,
+		gain: clip.gain,
+	}
+}
 
 const withinAudioPool = computed(() => !props.clip && typeof props.customWidthPx === 'number')
 
@@ -187,12 +380,32 @@ const initialClipState = computed(() => {
 })
 
 // Unified state that switches to drag preview values when active
+const isSelected = computed(() => {
+	if (!props.clip) return false
+	return selectedClipIds.has(props.clip.id)
+})
+
+const isPartOfMultiDrag = computed(() => {
+	return isSelected.value && multiDragState.value !== null
+})
+
 const displayState = computed(() => {
-	if (dragSession.value) {
+	if (dragSession.value && !dragSession.value.cloneSourceClipId) {
 		return {
 			start_beat: dragSession.value.previewStartBeat,
 			end_beat: dragSession.value.previewEndBeat,
 			offset_seconds: dragSession.value.previewOffsetSec,
+		}
+	}
+	if (isPartOfMultiDrag.value && multiDragState.value) {
+		const snap = multiDragState.value.clipSnapshots.get(props.clip!.id)
+		if (snap) {
+			const start = snap.origStartBeat + multiDragState.value.deltaBeats
+			return {
+				start_beat: start,
+				end_beat: snap.origEndBeat + multiDragState.value.deltaBeats,
+				offset_seconds: props.clip!.offset_seconds,
+			}
 		}
 	}
 	return initialClipState.value
@@ -211,10 +424,36 @@ const wrapperStyles = computed((): CSSProperties => {
 		left: `${beats_to_px(displayState.value.start_beat)}px`,
 	}
 
-	if (dragSession.value && dragSession.value.side === 'move') {
+	if (
+		dragSession.value &&
+		dragSession.value.side === 'move' &&
+		!dragSession.value.cloneSourceClipId
+	) {
 		const offset = dragSession.value.verticalOffsetPx
 		if (offset !== 0) {
 			base.top = `${offset}px`
+		}
+	} else if (
+		isPartOfMultiDrag.value &&
+		multiDragState.value &&
+		multiDragState.value.trackDelta !== 0
+	) {
+		// Multi-drag vertical movement visual offset
+		const snap = multiDragState.value.clipSnapshots.get(props.clip!.id)
+		if (snap && wrapperEl.value) {
+			const sorted = [...tracks.entries()].sort((a, b) => a[1].order_index - b[1].order_index)
+			const origTrackIdx = sorted.findIndex(([id]) => id === snap.origTrackId)
+			if (origTrackIdx !== -1) {
+				let targetTrackIdx = origTrackIdx + multiDragState.value.trackDelta
+				targetTrackIdx = Math.max(0, Math.min(sorted.length - 1, targetTrackIdx))
+
+				if (targetTrackIdx !== origTrackIdx) {
+					// We need to calculate pixel offset between orig track and target track
+					// This is tricky because we are inside the original track DOM
+					const offset = (targetTrackIdx - origTrackIdx) * pxTrackHeight
+					base.top = `${offset}px`
+				}
+			}
 		}
 	}
 
@@ -243,13 +482,38 @@ const dragSession = ref<{
 	currentY: number
 	previewTrackId: string | null
 	verticalOffsetPx: number
+	cloneSourceClipId: string | null
 	sourceTrackRect?: DOMRect
 } | null>(null)
+
+function clearOwnedMultiDrag() {
+	if (!props.clip || !multiDragState.value) return
+	if (multiDragState.value.sourceClipId === props.clip.id) {
+		multiDragState.value = null
+	}
+}
+
+function clearCloneDragPreview() {
+	cloneDragPreview.visible = false
+	cloneDragPreview.trackId = null
+	cloneDragPreview.audioFileId = null
+	cloneDragPreview.muted = false
+}
+
+function getTrackTopWithinTracksWrapper(trackRect?: DOMRect): number {
+	if (!trackRect || !wrapperEl.value) return 0
+	const tracksWrapper = wrapperEl.value.closest('.all-tracks-wrapper') as HTMLElement | null
+	if (!tracksWrapper) return 0
+	const wrapperRect = tracksWrapper.getBoundingClientRect()
+	return trackRect.top - wrapperRect.top
+}
 
 const windowFocused = useWindowFocus()
 watch(windowFocused, (focused) => {
 	if (!focused) {
 		dragSession.value = null
+		clearOwnedMultiDrag()
+		clearCloneDragPreview()
 	}
 })
 
@@ -261,7 +525,9 @@ onMounted(() => {
 
 		useEventListener(wrapperEl, 'pointerdown', (event) => {
 			if (user.value?.banned_at) return
+			if (event.button !== 0) return
 			event.preventDefault()
+
 			const rect = wrapperEl.value!.getBoundingClientRect()
 			const offsetX = event.clientX - rect.left
 
@@ -271,6 +537,31 @@ onMounted(() => {
 				clientX: event.clientX,
 				clientY: event.clientY,
 			}
+
+			const startX = event.clientX
+			const startY = event.clientY
+			const dragThreshold = 5
+			const dragThresholdSq = dragThreshold * dragThreshold
+			let moved = false
+
+			const onMove = (e: PointerEvent) => {
+				if (moved) return
+				const dx = e.clientX - startX
+				const dy = e.clientY - startY
+				moved = dx * dx + dy * dy > dragThresholdSq
+			}
+
+			const onUp = () => {
+				stopMove()
+				stopUp()
+
+				if (moved) return
+				if (!audioPoolPreviewOnClick.value) return
+				void previewAudioFile(props.audiofile.id)
+			}
+
+			const stopMove = useEventListener(window, 'pointermove', onMove)
+			const stopUp = useEventListener(window, 'pointerup', onUp)
 		})
 		return
 	}
@@ -285,15 +576,78 @@ onMounted(() => {
 			if (event.defaultPrevented) return
 			if (user.value?.banned_at) return
 
-			if (event.button === 2) {
-				return rip()
+			if (event.button !== 0) return
+			if (cloneDragPreview.visible) clearCloneDragPreview()
+			if (controlKeyPressed.value) {
+				// Ctrl+click: toggle this clip in/out of selection
+				if (props.clip) {
+					if (selectedClipIds.has(props.clip.id)) {
+						selectedClipIds.delete(props.clip.id)
+					} else {
+						selectedClipIds.add(props.clip.id)
+					}
+				}
+				event.preventDefault()
+				event.stopPropagation()
+				return
 			}
 
-			if (event.button !== 0) return
-			if (controlKeyPressed.value) return // Allow bubble for selection
+			if (props.clip && activeTool.value === 'hand') {
+				setBrushSourceFromClip(props.clip)
+			}
+
+			if (activeTool.value === 'mute') {
+				return
+			}
+
+			// In brush modes, clicking an existing clip acts as an eyedropper:
+			// update brush source only on a true click (not a drag),
+			// without moving or placing on this interaction.
+			if (
+				props.clip &&
+				(activeTool.value === 'brush' || activeTool.value === 'magic-brush')
+			) {
+				event.preventDefault()
+				event.stopPropagation()
+				clearOwnedMultiDrag()
+
+				const sourceClipId = props.clip.id
+				const startX = event.clientX
+				const startY = event.clientY
+				const dragThresholdPx = 5
+				const dragThresholdSq = dragThresholdPx * dragThresholdPx
+				let moved = false
+
+				const onMove = (e: PointerEvent) => {
+					if (moved) return
+					const dx = e.clientX - startX
+					const dy = e.clientY - startY
+					moved = dx * dx + dy * dy > dragThresholdSq
+				}
+
+				const onUp = () => {
+					stopMove()
+					stopUp()
+					if (moved) return
+
+					const sourceClip = clips.get(sourceClipId)
+					if (!sourceClip) return
+					setBrushSourceFromClip(sourceClip)
+				}
+
+				const stopMove = useEventListener(window, 'pointermove', onMove)
+				const stopUp = useEventListener(window, 'pointerup', onUp)
+				return
+			}
 
 			event.preventDefault()
 			event.stopPropagation()
+			clearOwnedMultiDrag()
+
+			if (activeTool.value === 'slice') {
+				void sliceClipAtPointer(event.clientX)
+				return
+			}
 
 			const parentTrack = (event.currentTarget as HTMLElement).closest('.track')
 
@@ -301,6 +655,8 @@ onMounted(() => {
 			if (parentTrack) {
 				sRect = parentTrack.getBoundingClientRect()
 			}
+			const isShiftCloneDrag =
+				!!props.clip && activeTool.value === 'hand' && shiftKeyPressed.value
 
 			dragSession.value = {
 				side: 'move',
@@ -315,11 +671,49 @@ onMounted(() => {
 				currentY: event.clientY,
 				previewTrackId: props.clip!.track_id,
 				verticalOffsetPx: 0,
+				cloneSourceClipId: isShiftCloneDrag ? props.clip!.id : null,
 				sourceTrackRect: sRect,
+			}
+
+			if (isShiftCloneDrag && props.clip) {
+				cloneDragPreview.visible = true
+				cloneDragPreview.trackId = props.clip.track_id
+				cloneDragPreview.audioFileId = props.clip.audio_file_id
+				cloneDragPreview.startBeat = initialClipState.value.start_beat
+				cloneDragPreview.endBeat = initialClipState.value.end_beat
+				cloneDragPreview.offsetSeconds = props.clip.offset_seconds
+				cloneDragPreview.gain = props.clip.gain
+				cloneDragPreview.muted = props.clip.muted
+				cloneDragPreview.topPx = getTrackTopWithinTracksWrapper(sRect)
+			} else {
+				clearCloneDragPreview()
 			}
 
 			const el = event.currentTarget as HTMLElement
 			el.setPointerCapture(event.pointerId)
+
+			// Initialize multi-drag if this clip is part of a selection
+			if (!isShiftCloneDrag && isSelected.value && !controlKeyPressed.value) {
+				const snapshots = new Map()
+				for (const id of selectedClipIds) {
+					const c = clips.get(id)
+					if (c) {
+						snapshots.set(id, {
+							origStartBeat: c.start_beat,
+							origEndBeat: c.end_beat,
+							origTrackId: c.track_id,
+						})
+					}
+				}
+				multiDragState.value = {
+					startX: event.clientX,
+					startY: event.clientY,
+					deltaBeats: 0,
+					trackDelta: 0,
+					sourceClipId: props.clip!.id,
+					clipSnapshots: snapshots,
+				}
+			}
 
 			const onMove = (e: PointerEvent) => {
 				const sesh = dragSession.value
@@ -334,17 +728,43 @@ onMounted(() => {
 				if (!altKeyPressed.value) {
 					deltaBeats = quantize_beats(deltaBeats)
 				}
+				const isLeaderOfMultiDrag =
+					multiDragState.value && multiDragState.value.sourceClipId === props.clip!.id
+				let clampedDeltaBeats = deltaBeats
+
+				if (isLeaderOfMultiDrag && multiDragState.value) {
+					let minStartBeat = Number.POSITIVE_INFINITY
+					let maxEndBeat = Number.NEGATIVE_INFINITY
+
+					for (const snap of multiDragState.value.clipSnapshots.values()) {
+						minStartBeat = Math.min(minStartBeat, snap.origStartBeat)
+						maxEndBeat = Math.max(maxEndBeat, snap.origEndBeat)
+					}
+
+					if (
+						Number.isFinite(minStartBeat) &&
+						Number.isFinite(maxEndBeat) &&
+						minStartBeat !== Number.POSITIVE_INFINITY &&
+						maxEndBeat !== Number.NEGATIVE_INFINITY
+					) {
+						const minDelta = -minStartBeat
+						const maxDelta = TOTAL_BEATS - maxEndBeat
+						clampedDeltaBeats = Math.max(minDelta, Math.min(maxDelta, deltaBeats))
+					}
+				}
 
 				const currentDuration = sesh.origEndBeat - sesh.origStartBeat
-				let newStart = sesh.origStartBeat + deltaBeats
-
-				// Clamp start to 0
-				newStart = Math.max(0, newStart)
-
-				let newEnd = newStart + currentDuration
-
-				// Crop end to TOTAL_BEATS
-				newEnd = Math.min(newEnd, TOTAL_BEATS)
+				let newStart: number
+				let newEnd: number
+				if (isLeaderOfMultiDrag) {
+					newStart = sesh.origStartBeat + clampedDeltaBeats
+					newEnd = sesh.origEndBeat + clampedDeltaBeats
+				} else {
+					newStart = sesh.origStartBeat + clampedDeltaBeats
+					newStart = Math.max(0, newStart)
+					newEnd = newStart + currentDuration
+					newEnd = Math.min(newEnd, TOTAL_BEATS)
+				}
 
 				sesh.previewStartBeat = newStart
 				sesh.previewEndBeat = newEnd
@@ -362,6 +782,72 @@ onMounted(() => {
 
 					sesh.verticalOffsetPx = snapY
 					sesh.previewTrackId = trackEl.dataset.trackId ?? null
+
+					if (sesh.cloneSourceClipId) {
+						cloneDragPreview.topPx = getTrackTopWithinTracksWrapper(targetRect)
+					}
+				}
+
+				if (sesh.cloneSourceClipId) {
+					cloneDragPreview.visible = true
+					cloneDragPreview.trackId = sesh.previewTrackId
+					cloneDragPreview.startBeat = sesh.previewStartBeat
+					cloneDragPreview.endBeat = sesh.previewEndBeat
+				}
+
+				// Update global multi-drag state if we are the leader
+				if (isLeaderOfMultiDrag && multiDragState.value) {
+					const state = multiDragState.value
+					const sorted = [...tracks.entries()].sort(
+						(a, b) => a[1].order_index - b[1].order_index,
+					)
+					const origTrackIdx = sorted.findIndex(([id]) => id === props.clip!.track_id)
+					const hoveredTrackIdx = sesh.previewTrackId
+						? sorted.findIndex(([id]) => id === sesh.previewTrackId)
+						: -1
+					const rawTrackDelta =
+						origTrackIdx !== -1 && hoveredTrackIdx !== -1
+							? hoveredTrackIdx - origTrackIdx
+							: state.trackDelta
+
+					let minOrigTrackIdx = Number.POSITIVE_INFINITY
+					let maxOrigTrackIdx = Number.NEGATIVE_INFINITY
+					for (const snap of state.clipSnapshots.values()) {
+						const idx = sorted.findIndex(([id]) => id === snap.origTrackId)
+						if (idx === -1) continue
+						minOrigTrackIdx = Math.min(minOrigTrackIdx, idx)
+						maxOrigTrackIdx = Math.max(maxOrigTrackIdx, idx)
+					}
+
+					let clampedTrackDelta = rawTrackDelta
+					if (
+						Number.isFinite(minOrigTrackIdx) &&
+						Number.isFinite(maxOrigTrackIdx) &&
+						minOrigTrackIdx !== Number.POSITIVE_INFINITY &&
+						maxOrigTrackIdx !== Number.NEGATIVE_INFINITY
+					) {
+						const minTrackDelta = -minOrigTrackIdx
+						const maxTrackDelta = sorted.length - 1 - maxOrigTrackIdx
+						clampedTrackDelta = Math.max(
+							minTrackDelta,
+							Math.min(maxTrackDelta, rawTrackDelta),
+						)
+					}
+
+					if (origTrackIdx !== -1) {
+						const clampedLeaderIdx = origTrackIdx + clampedTrackDelta
+						if (clampedLeaderIdx >= 0 && clampedLeaderIdx < sorted.length) {
+							sesh.previewTrackId = sorted[clampedLeaderIdx]![0]
+							sesh.verticalOffsetPx =
+								(clampedLeaderIdx - origTrackIdx) * pxTrackHeight
+						}
+					}
+
+					multiDragState.value = {
+						...state,
+						deltaBeats: clampedDeltaBeats,
+						trackDelta: clampedTrackDelta,
+					}
 				}
 			}
 
@@ -371,41 +857,173 @@ onMounted(() => {
 				stopUp()
 
 				const sesh = dragSession.value
-				if (!sesh || !props.clip) return
-
-				// Commit changes
-				const clip = clips.get(props.clip.id)
-				if (!clip) return
-
-				const changes: any = {
-					start_beat: sesh.previewStartBeat,
-					end_beat: sesh.previewEndBeat,
-				}
-
-				if (sesh.previewTrackId && sesh.previewTrackId !== clip.track_id) {
-					changes.track_id = sesh.previewTrackId
-				}
-
-				if (clip.id.startsWith('__temp__')) {
-					clip.start_beat = sesh.previewStartBeat
-					clip.end_beat = sesh.previewEndBeat
-					if (sesh.previewTrackId) clip.track_id = sesh.previewTrackId
+				if (!sesh || !props.clip) {
+					clearOwnedMultiDrag()
+					clearCloneDragPreview()
 					dragSession.value = null
 					return
 				}
 
-				const res = await socket.emitWithAck('get:clip:update', {
-					id: clip.id,
-					changes,
-				})
+				const leaderClipId = props.clip.id
+				const isLeaderOfMultiDrag =
+					multiDragState.value && multiDragState.value.sourceClipId === leaderClipId
 
-				if (res.success) {
-					clip.start_beat = res.data['start_beat'] ?? sesh.previewStartBeat
-					clip.end_beat = res.data['end_beat'] ?? sesh.previewEndBeat
-					if (res.data['track_id']) clip.track_id = res.data['track_id']
+				try {
+					if (isLeaderOfMultiDrag && multiDragState.value) {
+						const state = multiDragState.value
+						const sorted = [...tracks.entries()].sort(
+							(a, b) => a[1].order_index - b[1].order_index,
+						)
+
+						// Commit changes for all clips in the selection
+						for (const [id, snap] of state.clipSnapshots) {
+							const clip = clips.get(id)
+							if (!clip) continue
+
+							const newStart = snap.origStartBeat + state.deltaBeats
+							const newEnd = snap.origEndBeat + state.deltaBeats
+
+							const origTrackIdx = sorted.findIndex(
+								([tid]) => tid === snap.origTrackId,
+							)
+							const targetTrackIdx =
+								origTrackIdx !== -1 ? origTrackIdx + state.trackDelta : -1
+							const targetTrackId =
+								sorted.length > 0 &&
+								targetTrackIdx >= 0 &&
+								targetTrackIdx < sorted.length
+									? sorted[targetTrackIdx]![0]
+									: snap.origTrackId
+							const previousSnapshot: ClipMoveSnapshot = {
+								startBeat: clip.start_beat,
+								endBeat: clip.end_beat,
+								trackId: clip.track_id,
+							}
+							const expectedSnapshot: ClipMoveSnapshot = {
+								startBeat: newStart,
+								endBeat: newEnd,
+								trackId: targetTrackId,
+							}
+
+							// Optimistic update
+							clip.start_beat = newStart
+							clip.end_beat = newEnd
+							if (targetTrackId) clip.track_id = targetTrackId
+
+							// Temp clips are local-only optimistic placeholders.
+							if (clip.id.startsWith('__temp__')) continue
+
+							const changes: any = {
+								start_beat: newStart,
+								end_beat: newEnd,
+							}
+							if (targetTrackId !== previousSnapshot.trackId) {
+								changes.track_id = targetTrackId
+							}
+
+							socket
+								.emitWithAck('get:clip:update', {
+									id: clip.id,
+									changes,
+								})
+								.then((res) => {
+									if (res.success) {
+										clip.start_beat = res.data['start_beat'] ?? newStart
+										clip.end_beat = res.data['end_beat'] ?? newEnd
+										if (res.data['track_id'])
+											clip.track_id = res.data['track_id']
+										return
+									}
+
+									rollbackMoveIfUnchanged(id, expectedSnapshot, previousSnapshot)
+									userLog('SYSTEM', `Failed to move clip: ${res.error.message}`, {
+										textColor: 'red',
+									})
+								})
+								.catch(() => {
+									rollbackMoveIfUnchanged(id, expectedSnapshot, previousSnapshot)
+									userLog('SYSTEM', 'Failed to move clip: network error.', {
+										textColor: 'red',
+									})
+								})
+						}
+					} else {
+						// Single clip commit (standard logic)
+						const clip = clips.get(props.clip.id)
+						if (!clip) return
+
+						if (sesh.cloneSourceClipId) {
+							const sourceClip = clips.get(sesh.cloneSourceClipId)
+							if (!sourceClip) return
+
+							await createClipClone(sourceClip, {
+								startBeat: sesh.previewStartBeat,
+								endBeat: sesh.previewEndBeat,
+								trackId: sesh.previewTrackId ?? sourceClip.track_id,
+							})
+							return
+						}
+
+						const changes: any = {
+							start_beat: sesh.previewStartBeat,
+							end_beat: sesh.previewEndBeat,
+						}
+
+						if (sesh.previewTrackId && sesh.previewTrackId !== clip.track_id) {
+							changes.track_id = sesh.previewTrackId
+						}
+
+						if (clip.id.startsWith('__temp__')) {
+							clip.start_beat = sesh.previewStartBeat
+							clip.end_beat = sesh.previewEndBeat
+							if (sesh.previewTrackId) clip.track_id = sesh.previewTrackId
+							return
+						}
+
+						const previousSnapshot: ClipMoveSnapshot = {
+							startBeat: clip.start_beat,
+							endBeat: clip.end_beat,
+							trackId: clip.track_id,
+						}
+						const expectedSnapshot: ClipMoveSnapshot = {
+							startBeat: sesh.previewStartBeat,
+							endBeat: sesh.previewEndBeat,
+							trackId: sesh.previewTrackId ?? clip.track_id,
+						}
+
+						// Optimistic update
+						clip.start_beat = sesh.previewStartBeat
+						clip.end_beat = sesh.previewEndBeat
+						if (sesh.previewTrackId) clip.track_id = sesh.previewTrackId
+
+						try {
+							const res = await socket.emitWithAck('get:clip:update', {
+								id: clip.id,
+								changes,
+							})
+
+							if (res.success) {
+								clip.start_beat = res.data['start_beat'] ?? sesh.previewStartBeat
+								clip.end_beat = res.data['end_beat'] ?? sesh.previewEndBeat
+								if (res.data['track_id']) clip.track_id = res.data['track_id']
+							} else {
+								rollbackMoveIfUnchanged(clip.id, expectedSnapshot, previousSnapshot)
+								userLog('SYSTEM', `Failed to move clip: ${res.error.message}`, {
+									textColor: 'red',
+								})
+							}
+						} catch {
+							rollbackMoveIfUnchanged(clip.id, expectedSnapshot, previousSnapshot)
+							userLog('SYSTEM', 'Failed to move clip: network error.', {
+								textColor: 'red',
+							})
+						}
+					}
+				} finally {
+					clearOwnedMultiDrag()
+					clearCloneDragPreview()
+					dragSession.value = null
 				}
-
-				dragSession.value = null
 			}
 
 			const stopMove = useEventListener(window, 'pointermove', onMove)
@@ -419,9 +1037,6 @@ onMounted(() => {
 		'pointerdown',
 		(event) => {
 			if (user.value?.banned_at) return
-			if (event.button === 2) {
-				return rip()
-			}
 
 			if (event.button !== 0) return
 			event.preventDefault()
@@ -440,6 +1055,7 @@ onMounted(() => {
 				currentY: event.clientY,
 				previewTrackId: props.clip!.track_id, // We know clip exists if not withinAudioPool
 				verticalOffsetPx: 0,
+				cloneSourceClipId: null,
 			}
 
 			const el = event.currentTarget as HTMLElement
@@ -543,9 +1159,6 @@ onMounted(() => {
 		'pointerdown',
 		(event) => {
 			if (user.value?.banned_at) return
-			if (event.button === 2) {
-				return rip()
-			}
 
 			if (event.button !== 0) return
 			event.preventDefault()
@@ -564,6 +1177,7 @@ onMounted(() => {
 				currentY: event.clientY,
 				previewTrackId: props.clip!.track_id,
 				verticalOffsetPx: 0,
+				cloneSourceClipId: null,
 			}
 
 			const el = event.currentTarget as HTMLElement
@@ -636,12 +1250,6 @@ onMounted(() => {
 		},
 		{ passive: false },
 	)
-
-	useEventListener(wrapperEl, 'pointerenter', () => {
-		if (rightMouseButtonPressedOnTimeline.value) {
-			rip()
-		}
-	})
 })
 
 const canvasStyles = computed((): CSSProperties => {
@@ -787,6 +1395,11 @@ function getWaveform(
 
 .outmostClipWrapper.selected .outerClipCanvasWrap {
 	background-color: rgba(255, 25, 25, 0.2) !important;
+}
+
+.outmostClipWrapper.muted:not(.selected) {
+	opacity: 0.5;
+	filter: grayscale(1) saturate(0.2);
 }
 
 .clipHeader {

--- a/src/components/TimelineHeader.vue
+++ b/src/components/TimelineHeader.vue
@@ -2,6 +2,7 @@
 	<div
 		class="no-select timeline-header-wrap"
 		@dblclick="handleDoubleClick"
+		@contextmenu.prevent
 		:style="{ cursor: cursorStyle }"
 	>
 		<div class="timeline-header" ref="timelineHeaderRef">
@@ -50,7 +51,7 @@
 
 	<!-- Sticky Playhead Heads -->
 	<div class="timeline-heads-wrap">
-		<div v-if="!isPressed" class="resting-playhead-head" :style="restingPlayheadStyle" />
+		<div v-if="!isPointerDown" class="resting-playhead-head" :style="restingPlayheadStyle" />
 		<div
 			class="playhead-head"
 			:style="playheadHeadStyle"
@@ -78,23 +79,17 @@ import {
 	sec_to_beats,
 } from '@/utils/mathUtils'
 import { computed, shallowRef, useTemplateRef, watch, type CSSProperties } from 'vue'
-import { altKeyPressed, controlKeyPressed, shiftKeyPressed, pxPerBeat, TOTAL_BEATS } from '@/state'
-import { useMouseInElement, useMousePressed, useWindowFocus, watchThrottled } from '@vueuse/core'
+import { altKeyPressed, pxPerBeat, TOTAL_BEATS } from '@/state'
+import { useEventListener, useWindowFocus } from '@vueuse/core'
 
 const timelineHeaderEl = useTemplateRef('timelineHeaderRef')
-const { elementX: mouseX } = useMouseInElement(timelineHeaderEl, { handleOutside: true })
-const { pressed: isPressed } = useMousePressed({ target: timelineHeaderEl })
+const isPointerDown = shallowRef(false)
 
 const windowFocused = useWindowFocus()
 
 watch(windowFocused, (focused) => {
 	if (!focused) {
-		isPressed.value = false
-		localPlayheadBeat.value = null
-		startedScrubWithActionKey.value = null
-		activeHandle.value = null
-		loopDragStartBeat.value = null
-		loopDragEndBeat.value = null
+		clearDragState()
 	}
 })
 
@@ -127,13 +122,12 @@ const playHeadPosPx = computed(() => {
 	return beats_to_px(sec_to_beats(currentTime.value))
 })
 
-const isActionKeyPressed = computed(() => controlKeyPressed.value || shiftKeyPressed.value)
-
 // Loop Drag State
 const loopDragStartBeat = shallowRef<number | null>(null)
 const loopDragEndBeat = shallowRef<number | null>(null)
-const activeHandle = shallowRef<'start' | 'end' | null>(null)
-const startedScrubWithActionKey = shallowRef<boolean | null>(null)
+const startedLoopDrag = shallowRef(false)
+const dragStartPoint = shallowRef<{ x: number; y: number } | null>(null)
+const dragMode = shallowRef<'seek' | 'loop' | null>(null)
 
 const displayLoopRange = computed(() => {
 	if (loopDragStartBeat.value != null && loopDragEndBeat.value != null) {
@@ -154,138 +148,111 @@ const loopWidthPx = computed(() =>
 		: 0,
 )
 
-const isHoveringHandle = computed(() => {
-	if (!loopRangeBeats.value) return false
-	const startPx = beats_to_px(loopRangeBeats.value.start)
-	const endPx = beats_to_px(loopRangeBeats.value.end)
-	const distStart = Math.abs(mouseX.value - startPx)
-	const distEnd = Math.abs(mouseX.value - endPx)
-	const thresholdPx = 7
-	return distStart < thresholdPx || distEnd < thresholdPx
-})
-
 const cursorStyle = computed(() => {
-	if (startedScrubWithActionKey.value && activeHandle.value) return 'ew-resize'
-	if (isHoveringHandle.value) return 'ew-resize'
-	if (isActionKeyPressed.value) return 'text' // or 'crosshair'
+	if (isPointerDown.value && dragMode.value === 'loop') return 'ew-resize'
 	return 'default'
 })
 
-watch([isPressed, mouseX], ([pressed, newMouseX]) => {
-	if (!timelineHeaderEl.value) return
+// corx2026 throwback + Larian dedication:
+// we fixed the old scrub/loop edge cases by centralizing beat clamping
+// and driving drag state from pointer capture (down/move/up), so no more ghost states.
+const clampBeat = (beat: number) => Math.max(0, Math.min(beat, TOTAL_BEATS))
 
-	// --- RELEASED ---
-	if (!pressed) {
-		if (startedScrubWithActionKey.value) {
-			// Commit loop
-			const start = loopDragStartBeat.value
-			const end = loopDragEndBeat.value
-			if (start != null && end != null) {
-				if (Math.abs(start - end) > 0.0001) {
-					setLoopInBeats(start, end, { quantize: false })
-				} else {
-					clearLoop()
-				}
-			}
+function beatFromClientX(clientX: number): number {
+	if (!timelineHeaderEl.value) return 0
+	const rect = timelineHeaderEl.value.getBoundingClientRect()
+	const relX = clientX - rect.left
+	const rawBeat = px_to_beats(relX)
+	const beat = altKeyPressed.value ? rawBeat : quantize_beats(rawBeat)
+	return clampBeat(beat)
+}
+
+function clearDragState() {
+	isPointerDown.value = false
+	startedLoopDrag.value = false
+	dragStartPoint.value = null
+	dragMode.value = null
+	loopDragStartBeat.value = null
+	loopDragEndBeat.value = null
+	localPlayheadBeat.value = null
+}
+
+useEventListener(
+	timelineHeaderEl,
+	'pointerdown',
+	(event) => {
+		if (event.button !== 0 && event.button !== 2) return
+		if (!timelineHeaderEl.value) return
+
+		event.preventDefault()
+		event.stopPropagation()
+
+		const startBeat = beatFromClientX(event.clientX)
+		isPointerDown.value = true
+		startedLoopDrag.value = false
+		dragStartPoint.value = { x: event.clientX, y: event.clientY }
+		dragMode.value = event.button === 2 ? 'loop' : 'seek'
+		if (dragMode.value === 'loop') {
+			loopDragStartBeat.value = startBeat
+			loopDragEndBeat.value = startBeat
+			localPlayheadBeat.value = null
+		} else {
 			loopDragStartBeat.value = null
 			loopDragEndBeat.value = null
+			localPlayheadBeat.value = startBeat
 		}
 
-		localPlayheadBeat.value = null
-		startedScrubWithActionKey.value = null
-		activeHandle.value = null
-		return
-	}
+		const dragThresholdPx = 5
+		const dragThresholdSq = dragThresholdPx * dragThresholdPx
+		const el = event.currentTarget as HTMLElement
+		el.setPointerCapture(event.pointerId)
 
-	// --- PRESSED ---
+		const onMove = (e: PointerEvent) => {
+			if (!isPointerDown.value || !dragStartPoint.value) return
 
-	const beats = px_to_beats(newMouseX)
+			const dx = e.clientX - dragStartPoint.value.x
+			const dy = e.clientY - dragStartPoint.value.y
+			if (!startedLoopDrag.value && dx * dx + dy * dy > dragThresholdSq) {
+				startedLoopDrag.value = true
+			}
 
-	// Initialize drag mode on first press frame
-	if (startedScrubWithActionKey.value == null) {
-		startedScrubWithActionKey.value = isActionKeyPressed.value
-
-		// If NOT holding action key, check if we clicked a loop handle
-		if (!startedScrubWithActionKey.value && loopRangeBeats.value) {
-			const startPx = beats_to_px(loopRangeBeats.value.start)
-			const endPx = beats_to_px(loopRangeBeats.value.end)
-			const distStart = Math.abs(newMouseX - startPx)
-			const distEnd = Math.abs(newMouseX - endPx)
-			const thresholdPx = 15 // px proximity
-
-			// Prioritize the handle that is closer
-			if (distStart < thresholdPx || distEnd < thresholdPx) {
-				startedScrubWithActionKey.value = true
-
-				// Helper to set state
-				const setDragState = (handle: 'start' | 'end') => {
-					activeHandle.value = handle
-					loopDragStartBeat.value = loopRangeBeats.value!.start
-					loopDragEndBeat.value = loopRangeBeats.value!.end
-				}
-
-				if (distStart < thresholdPx && distEnd < thresholdPx) {
-					// Both minimal? Pick closest
-					if (distStart < distEnd) setDragState('start')
-					else setDragState('end')
-				} else if (distStart < thresholdPx) {
-					setDragState('start')
-				} else {
-					setDragState('end')
-				}
+			const beat = beatFromClientX(e.clientX)
+			if (dragMode.value === 'loop') {
+				loopDragEndBeat.value = beat
+			} else {
+				localPlayheadBeat.value = beat
 			}
 		}
-	}
 
-	// 1. Regular Scrub
-	if (!startedScrubWithActionKey.value) {
-		const beat = altKeyPressed.value ? beats : quantize_beats(beats)
-		localPlayheadBeat.value = Math.max(0, beat)
-		return
-	}
+		const onUp = (e: PointerEvent) => {
+			stopMove()
+			stopUp()
+			el.releasePointerCapture(event.pointerId)
 
-	// 2. Loop Dragging / Editing
+			const releaseBeat = beatFromClientX(e.clientX)
+			const start = loopDragStartBeat.value
+			const end = loopDragEndBeat.value ?? releaseBeat
 
-	// If new drag (no handle yet), decide handle or create new
-	if (loopDragStartBeat.value == null) {
-		// New loop creation
-		// (Logic for grabbing handle was done in init above, so if we are here and
-		// activeHandle is null, it's a fresh create)
+			if (dragMode.value === 'loop') {
+				if (start != null && end != null && Math.abs(start - end) > 0.0001) {
+					setLoopInBeats(start, end, { quantize: false })
+				}
+			} else {
+				seek(beats_to_sec(releaseBeat), { setAsRest: true })
+			}
 
-		const initialBeat = altKeyPressed.value ? beats : quantize_beats(beats)
-		loopDragStartBeat.value = initialBeat
-		loopDragEndBeat.value = initialBeat
+			clearDragState()
+		}
 
-		// Decide which end is moving based on direction?
-		// Actually let's just update endBeat freely, and swap min/max in computed.
-		// "activeHandle" is basically "the one I'm dragging right now".
-		// For creation, we can say we are dragging 'end' relative to 'start'.
-		activeHandle.value = 'end'
-	}
-
-	// Update the active handle
-	const currentBeat = altKeyPressed.value ? beats : quantize_beats(beats)
-	// pro fix by corx music 2026 edition
-	const clampedBeat = (beat: number) => Math.max(0, Math.min(beat, TOTAL_BEATS))
-	if (activeHandle.value === 'start') {
-		loopDragStartBeat.value = clampedBeat(currentBeat)
-	} else {
-		loopDragEndBeat.value = clampedBeat(currentBeat)
-	}
-})
+		const stopMove = useEventListener(window, 'pointermove', onMove)
+		const stopUp = useEventListener(window, 'pointerup', onUp)
+	},
+	{ passive: false },
+)
 
 function handleDoubleClick() {
 	clearLoop()
 }
-
-watchThrottled(
-	localPlayheadBeat,
-	(newBeat) => {
-		if (newBeat == null) return
-		seek(beats_to_sec(newBeat), { setAsRest: true })
-	},
-	{ throttle: 100, trailing: true },
-)
 </script>
 
 <style scoped>

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { activeTool, type ToolMode } from '@/state'
+import { Hand, Paintbrush, Sparkles, Scissors, VolumeX } from 'lucide-vue-next'
+import { useEventListener } from '@vueuse/core'
+
+const tools: {
+	mode: ToolMode
+	icon: typeof Hand
+	label: string
+	shortcut: string
+	color: string
+}[] = [
+	{ mode: 'hand', icon: Hand, label: 'Hand', shortcut: 'H', color: 'var(--text-color-primary)' },
+	{ mode: 'brush', icon: Paintbrush, label: 'Brush', shortcut: 'B', color: '#4fb8ff' },
+	{ mode: 'magic-brush', icon: Sparkles, label: 'Magic Brush', shortcut: 'G', color: '#ffb347' },
+	{ mode: 'slice', icon: Scissors, label: 'Slice', shortcut: 'C', color: '#ff6b6b' },
+	{ mode: 'mute', icon: VolumeX, label: 'Mute', shortcut: '0', color: '#b9bec8' },
+]
+
+useEventListener(window, 'keydown', (e) => {
+	// Don't intercept when typing in inputs
+	if (
+		(e.target as HTMLElement).tagName === 'INPUT' ||
+		(e.target as HTMLElement).tagName === 'TEXTAREA'
+	)
+		return
+	if (e.ctrlKey || e.metaKey || e.altKey) return
+
+	if (e.key.toLowerCase() === 'h') activeTool.value = 'hand'
+	if (e.key.toLowerCase() === 'b') activeTool.value = 'brush'
+	if (e.key.toLowerCase() === 'g') activeTool.value = 'magic-brush'
+	if (e.key.toLowerCase() === 'c') activeTool.value = 'slice'
+	if (e.key === '0') activeTool.value = 'mute'
+})
+</script>
+
+<template>
+	<div class="toolbar">
+		<button
+			v-for="tool in tools"
+			:key="tool.mode"
+			class="controls-panel-btn toolbar-btn"
+			:class="[{ active: activeTool === tool.mode }, `tool-${tool.mode}`]"
+			:title="`${tool.label} (${tool.shortcut})`"
+			:style="{ '--tool-color': tool.color }"
+			@click="activeTool = tool.mode"
+		>
+			<component :is="tool.icon" :size="16" />
+		</button>
+	</div>
+</template>
+
+<style scoped>
+.toolbar {
+	display: flex;
+	align-items: center;
+	gap: 0;
+	margin-left: 1rem;
+}
+
+.toolbar-btn {
+	border-left: none;
+	color: var(--text-color-primary);
+	transition:
+		box-shadow 120ms,
+		background-color 150ms,
+		color 120ms;
+}
+
+.toolbar-btn:first-child {
+	border-left: 1px solid var(--border-primary);
+}
+
+.toolbar-btn.active {
+	z-index: 21;
+	color: var(--tool-color);
+	box-shadow:
+		0px 0px 34px -14px var(--tool-color),
+		inset 0px 0px 6px -2px var(--tool-color),
+		inset 0px 0px 18px -7px var(--tool-color);
+}
+
+.toolbar-btn.active :deep(svg) {
+	filter: drop-shadow(0 0 0.3rem color-mix(in lch, var(--tool-color), transparent 60%));
+}
+</style>

--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -64,6 +64,97 @@
 					padding-bottom: 0.5rem;
 				"
 			></div>
+
+			<button class="default-button menu-btn" @click="copySelection">
+				<Copy class="dim" :size="14" :stroke-width="2" />
+				<p>Copy</p>
+				<div class="shortcut-container mono">
+					<p class="kbd">Ctrl</p>
+					<p class="kbd">C</p>
+				</div>
+			</button>
+
+			<button class="default-button menu-btn" @click="pasteClips">
+				<ClipboardPaste class="dim" :size="14" :stroke-width="2" />
+				<p>Paste</p>
+				<div class="shortcut-container mono">
+					<p class="kbd">Ctrl</p>
+					<p class="kbd">V</p>
+				</div>
+			</button>
+
+			<button class="default-button menu-btn" @click="duplicateSelection">
+				<CopyPlus class="dim" :size="14" :stroke-width="2" />
+				<p>Duplicate</p>
+				<div class="shortcut-container mono">
+					<p class="kbd">Ctrl</p>
+					<p class="kbd">D</p>
+				</div>
+			</button>
+
+			<button class="default-button menu-btn" @click="deleteSelection">
+				<Trash2 class="dim" :size="14" :stroke-width="2" />
+				<p>Delete Selection</p>
+				<div class="shortcut-container mono">
+					<p class="kbd">Del</p>
+				</div>
+			</button>
+
+			<div
+				style="
+					border-top: 1px solid var(--border-primary);
+					margin-top: 0.5rem;
+					padding-bottom: 0.5rem;
+				"
+			></div>
+
+			<button class="default-button menu-btn" @click="activeTool = 'hand'">
+				<Hand class="dim" :size="14" :stroke-width="2" />
+				<p>Hand Tool</p>
+				<div class="shortcut-container mono">
+					<p class="kbd">H</p>
+				</div>
+			</button>
+
+			<button class="default-button menu-btn" @click="activeTool = 'brush'">
+				<Paintbrush class="dim" :size="14" :stroke-width="2" />
+				<p>Brush Tool</p>
+				<div class="shortcut-container mono">
+					<p class="kbd">B</p>
+				</div>
+			</button>
+
+			<button class="default-button menu-btn" @click="activeTool = 'magic-brush'">
+				<Sparkles class="dim" :size="14" :stroke-width="2" />
+				<p>Magic Brush</p>
+				<div class="shortcut-container mono">
+					<p class="kbd">G</p>
+				</div>
+			</button>
+
+			<button class="default-button menu-btn" @click="activeTool = 'slice'">
+				<Scissors class="dim" :size="14" :stroke-width="2" />
+				<p>Slice Tool</p>
+				<div class="shortcut-container mono">
+					<p class="kbd">C</p>
+				</div>
+			</button>
+
+			<button class="default-button menu-btn" @click="activeTool = 'mute'">
+				<VolumeX class="dim" :size="14" :stroke-width="2" />
+				<p>Mute Tool</p>
+				<div class="shortcut-container mono">
+					<p class="kbd">0</p>
+				</div>
+			</button>
+
+			<div
+				style="
+					border-top: 1px solid var(--border-primary);
+					margin-top: 0.5rem;
+					padding-bottom: 0.5rem;
+				"
+			></div>
 			<button
 				class="default-button menu-btn"
 				@click="openBugReport"
@@ -78,17 +169,17 @@
 					:style="{ opacity: isBugButtonHovered ? 1 : 0 }"
 				/>
 			</button>
-			<button class="default-button menu-btn">
+			<button class="default-button menu-btn" @click="showSettingsComingSoon">
 				<Settings2 class="dim" :size="16" :stroke-width="2" />
 				<p>Settings</p>
 			</button>
 			<div style="padding: 0 0.5rem; margin-top: 0.5rem; margin-bottom: 0.5rem">
 				<label
-				for="download-quality"
-				class="txt small dim"
-				style="display: block; margin-bottom: 0.2rem"
+					for="download-quality"
+					class="txt small dim"
+					style="display: block; margin-bottom: 0.2rem"
 				>
-				Download Format
+					Download Format
 				</label>
 				<select
 					id="download-quality"
@@ -177,7 +268,15 @@
 
 <script setup lang="ts">
 import { socket } from '@/socket/socket'
-import { user, controlKeyPressed, zKeyPressed, tKeyPressed, lKeyPressed } from '@/state'
+import {
+	user,
+	controlKeyPressed,
+	zKeyPressed,
+	tKeyPressed,
+	lKeyPressed,
+	activeTool,
+	showAdminPanel,
+} from '@/state'
 import {
 	UserPen,
 	Settings2,
@@ -190,6 +289,15 @@ import {
 	Repeat,
 	Shield,
 	Lock,
+	Copy,
+	ClipboardPaste,
+	CopyPlus,
+	Trash2,
+	Hand,
+	Paintbrush,
+	Sparkles,
+	Scissors,
+	VolumeX,
 } from 'lucide-vue-next'
 import { nextTick, shallowRef, useTemplateRef, watch, computed } from 'vue'
 import { useRouter } from 'vue-router'
@@ -197,7 +305,11 @@ import { sanitizeLetterUnderscoreOnly } from '~/utils'
 import { vElementHover } from '@vueuse/components'
 import { isLooping, isPlaying, reset } from '@/audioEngine'
 import { updateDisplayNamesForUser } from '@/socket/eventHandlers/user_username_change'
-import { showAdminPanel } from '@/state'
+import { useClipboardActions } from '@/composables/useClipboardActions'
+
+const { copySelection, pasteClips, duplicateSelection, deleteSelection } = useClipboardActions({
+	bindKeyboard: false,
+})
 
 const isBugButtonHovered = shallowRef(false)
 function onBugHover(hovered: boolean) {
@@ -222,6 +334,10 @@ function signout() {
 
 function openBugReport() {
 	window.open('https://github.com/mofalkmusic/megacollab/issues', '_blank')
+}
+
+function showSettingsComingSoon() {
+	window.alert('Work in progress :)')
 }
 
 const isEditingUsername = shallowRef(false)
@@ -333,7 +449,8 @@ async function updateDownloadQuality(event: Event) {
 	display: grid;
 	border-radius: inherit;
 	padding: 0.5rem;
-	max-width: 20rem;
+	min-width: 22.75rem;
+	max-width: 24.5rem;
 	box-shadow: 0px 0px 1rem 0rem var(--bg-color);
 }
 
@@ -370,6 +487,7 @@ async function updateDownloadQuality(event: Event) {
 	box-shadow: none;
 	justify-content: flex-start;
 	white-space: nowrap;
+	padding-right: 1.5rem;
 }
 
 .menu-btn:hover {

--- a/src/components/tracks/TrackInstance.vue
+++ b/src/components/tracks/TrackInstance.vue
@@ -129,6 +129,7 @@ const { isOverDropZone } = useDropZone(trackEl, {
 			end_beat: endBeat,
 			offset_seconds: 0,
 			gain: 1,
+			muted: false,
 			created_at: new Date().toISOString(),
 		}
 
@@ -149,6 +150,7 @@ const { isOverDropZone } = useDropZone(trackEl, {
 					end_beat: currentClip.end_beat,
 					offset_seconds: currentClip.offset_seconds,
 					gain: currentClip.gain,
+					muted: currentClip.muted,
 				})
 
 				if (syncRes.success) {

--- a/src/composables/__tests__/useClipboardActions.test.ts
+++ b/src/composables/__tests__/useClipboardActions.test.ts
@@ -1,0 +1,218 @@
+import { beforeAll, beforeEach, describe, expect, test, mock } from 'bun:test'
+import { reactive, ref, shallowRef } from 'vue'
+import type { Clip } from '~/schema'
+
+const TOTAL_BEATS = 16 * 16
+
+const clips = reactive<Map<string, Clip>>(new Map())
+const selectedClipIds = reactive<Set<string>>(new Set())
+const clipboardClips = shallowRef<any[] | null>(null)
+const tracks = reactive<Map<string, { id: string; order_index: number }>>(new Map())
+const user = ref<any>(null)
+const pxPerBeat = shallowRef(40)
+const bpm = 128
+const currentPlayTimeBeats = shallowRef(0)
+
+const socketCalls: Array<{ event: string; data: any }> = []
+const logs: Array<{ sender: string; text: string }> = []
+
+let nextAck:
+	| { success: true; data: any[] }
+	| { success: false; error: { message: string } }
+	| ((event: string, data: any) => any) = { success: true, data: [] }
+
+const emitWithAck = async (event: string, data: any) => {
+	socketCalls.push({ event, data })
+	if (typeof nextAck === 'function') return await nextAck(event, data)
+	return nextAck
+}
+
+mock.module('@/state', () => ({
+	clips,
+	selectedClipIds,
+	clipboardClips,
+	tracks,
+	user,
+	pxPerBeat,
+	bpm,
+	TOTAL_BEATS,
+}))
+
+mock.module('@/audioEngine', () => ({
+	currentPlayTimeBeats,
+}))
+
+mock.module('@/socket/socket', () => ({
+	socket: {
+		emitWithAck,
+	},
+}))
+
+mock.module('@/composables/useConsole', () => ({
+	useConsole: () => ({
+		userLog: (sender: string, text: string) => {
+			logs.push({ sender, text })
+		},
+	}),
+}))
+
+let useClipboardActions: (opts?: { bindKeyboard?: boolean }) => {
+	copySelection: () => void
+	pasteClips: () => Promise<void>
+	duplicateSelection: () => Promise<void>
+	deleteSelection: () => Promise<void>
+}
+
+function makeClip(partial: Partial<Clip> & { id: string }): Clip {
+	return {
+		id: partial.id,
+		track_id: partial.track_id ?? 't1',
+		audio_file_id: partial.audio_file_id ?? 'af1',
+		creator_user_id: partial.creator_user_id ?? 'u1',
+		creator_display_name: partial.creator_display_name ?? 'Test',
+		start_beat: partial.start_beat ?? 0,
+		end_beat: partial.end_beat ?? 4,
+		offset_seconds: partial.offset_seconds ?? 0,
+		gain: partial.gain ?? 1,
+		muted: partial.muted ?? false,
+		created_at: partial.created_at ?? new Date().toISOString(),
+	}
+}
+
+beforeAll(async () => {
+	;({ useClipboardActions } = await import('../useClipboardActions'))
+})
+
+beforeEach(() => {
+	clips.clear()
+	selectedClipIds.clear()
+	tracks.clear()
+	tracks.set('t1', { id: 't1', order_index: 0 })
+	tracks.set('t2', { id: 't2', order_index: 1 })
+	clipboardClips.value = null
+	user.value = { id: 'u1', display_name: 'Test', banned_at: null }
+	currentPlayTimeBeats.value = 0
+	socketCalls.length = 0
+	logs.length = 0
+	nextAck = { success: true, data: [] }
+})
+
+describe('useClipboardActions', () => {
+	test('pasteClips sends one batch request and skips out-of-bounds clips', async () => {
+		clipboardClips.value = [
+			{
+				relStartBeat: 0,
+				relEndBeat: 2,
+				trackOffset: 0,
+				audioFileId: 'af1',
+				offsetSeconds: 0,
+				gain: 1,
+				muted: false,
+			},
+			{
+				relStartBeat: 2,
+				relEndBeat: 8,
+				trackOffset: 0,
+				audioFileId: 'af1',
+				offsetSeconds: 0,
+				gain: 1,
+				muted: false,
+			},
+		]
+		currentPlayTimeBeats.value = 254
+
+		nextAck = (event, data) => {
+			expect(event).toBe('get:clips:create:batch')
+			expect(data.clips).toHaveLength(1)
+			expect(data.clips[0]).toMatchObject({
+				start_beat: 254,
+				end_beat: 256,
+			})
+			return {
+				success: true,
+				data: [makeClip({ id: 'server_clip_1', start_beat: 254, end_beat: 256 })],
+			}
+		}
+
+		const { pasteClips } = useClipboardActions({ bindKeyboard: false })
+		await pasteClips()
+
+		expect(socketCalls).toHaveLength(1)
+		expect(clips.has('server_clip_1')).toBe(true)
+		expect([...selectedClipIds]).toEqual(['server_clip_1'])
+	})
+
+	test('pasteClips out-of-bounds only does not emit and preserves selection', async () => {
+		const existing = makeClip({ id: 'existing', start_beat: 8, end_beat: 10, track_id: 't1' })
+		clips.set(existing.id, existing)
+		selectedClipIds.add(existing.id)
+
+		clipboardClips.value = [
+			{
+				relStartBeat: 0,
+				relEndBeat: 2,
+				trackOffset: 0,
+				audioFileId: 'af1',
+				offsetSeconds: 0,
+				gain: 1,
+				muted: false,
+			},
+		]
+		currentPlayTimeBeats.value = TOTAL_BEATS
+
+		const { pasteClips } = useClipboardActions({ bindKeyboard: false })
+		await pasteClips()
+
+		expect(socketCalls).toHaveLength(0)
+		expect([...selectedClipIds]).toEqual([existing.id])
+		expect(logs.some((l) => l.text.includes('Nothing pasted'))).toBe(true)
+	})
+
+	test('duplicateSelection sends one batch request for multi-clip selection', async () => {
+		const c1 = makeClip({ id: 'c1', start_beat: 0, end_beat: 2, track_id: 't1' })
+		const c2 = makeClip({ id: 'c2', start_beat: 2, end_beat: 4, track_id: 't1' })
+		clips.set(c1.id, c1)
+		clips.set(c2.id, c2)
+		selectedClipIds.add(c1.id)
+		selectedClipIds.add(c2.id)
+
+		nextAck = (event, data) => {
+			expect(event).toBe('get:clips:create:batch')
+			expect(data.clips).toHaveLength(2)
+			expect(data.clips[0]).toMatchObject({ start_beat: 4, end_beat: 6 })
+			expect(data.clips[1]).toMatchObject({ start_beat: 6, end_beat: 8 })
+			return {
+				success: true,
+				data: [
+					makeClip({ id: 'dup1', start_beat: 4, end_beat: 6 }),
+					makeClip({ id: 'dup2', start_beat: 6, end_beat: 8 }),
+				],
+			}
+		}
+
+		const { duplicateSelection } = useClipboardActions({ bindKeyboard: false })
+		await duplicateSelection()
+
+		expect(socketCalls).toHaveLength(1)
+		expect(socketCalls[0]?.event).toBe('get:clips:create:batch')
+		expect(clips.has('dup1')).toBe(true)
+		expect(clips.has('dup2')).toBe(true)
+		expect(new Set(selectedClipIds)).toEqual(new Set(['dup1', 'dup2']))
+	})
+
+	test('duplicateSelection out-of-bounds only does not emit and preserves selection', async () => {
+		const c1 = makeClip({ id: 'c1', start_beat: 250, end_beat: 254, track_id: 't1' })
+		const c2 = makeClip({ id: 'c2', start_beat: 254, end_beat: 256, track_id: 't1' })
+		clips.set(c1.id, c1)
+		clips.set(c2.id, c2)
+		selectedClipIds.add(c1.id)
+		selectedClipIds.add(c2.id)
+
+		const { duplicateSelection } = useClipboardActions({ bindKeyboard: false })
+		await duplicateSelection()
+
+		expect(socketCalls).toHaveLength(0)
+		expect(new Set(selectedClipIds)).toEqual(new Set(['c1', 'c2']))
+		expect(logs.some((l) => l.text.includes('Nothing duplicated'))).toBe(true)
+	})
+})

--- a/src/composables/useBrushTool.ts
+++ b/src/composables/useBrushTool.ts
@@ -1,0 +1,420 @@
+import { useEventListener } from '@vueuse/core'
+import { computed, reactive, shallowRef, watch, type ShallowRef } from 'vue'
+import {
+	activeTool,
+	brushAudioFileId,
+	brushSourceClip,
+	audiofiles,
+	clips,
+	tracks,
+	user,
+	TOTAL_BEATS,
+	pxTrackHeight,
+	altKeyPressed,
+	controlKeyPressed,
+} from '@/state'
+import { px_to_beats, quantize_beats, sec_to_beats } from '@/utils/mathUtils'
+import { socket } from '@/socket/socket'
+import { useConsole } from '@/composables/useConsole'
+import { nanoid } from 'nanoid'
+import type { Clip } from '~/schema'
+
+export function useBrushTool(tracksWrapperEl: Readonly<ShallowRef<HTMLElement | null>>) {
+	const { userLog } = useConsole()
+
+	const isBrushActive = computed(
+		() =>
+			(activeTool.value === 'brush' || activeTool.value === 'magic-brush') &&
+			!controlKeyPressed.value,
+	)
+
+	const brushDragState = shallowRef<{
+		trackId: string
+		nextRightBeat: number
+		nextLeftBeat: number
+		firstClipStartBeat: number
+		direction: 'right' | 'left' | null
+		placedClipIds: string[]
+	} | null>(null)
+
+	// --- Hover preview ---
+	const brushPreview = reactive<{
+		visible: boolean
+		startBeat: number
+		endBeat: number
+		trackId: string | null
+		topPx: number
+	}>({
+		visible: false,
+		startBeat: 0,
+		endBeat: 0,
+		trackId: null,
+		topPx: 0,
+	})
+
+	type BrushPlacementSource = {
+		audioFileId: string
+		lengthBeats: number
+		offsetSeconds: number
+		gain: number
+	}
+
+	function getAudioFile() {
+		if (!brushAudioFileId.value) return null
+		return audiofiles.get(brushAudioFileId.value) ?? null
+	}
+
+	function getBrushPlacementSource(): BrushPlacementSource | null {
+		const audioFile = getAudioFile()
+		if (!audioFile) return null
+
+		if (brushSourceClip.value && brushSourceClip.value.audioFileId === audioFile.id) {
+			return {
+				audioFileId: audioFile.id,
+				lengthBeats: Math.max(0.01, brushSourceClip.value.lengthBeats),
+				offsetSeconds: Math.max(0, brushSourceClip.value.offsetSeconds),
+				gain: brushSourceClip.value.gain,
+			}
+		}
+
+		return {
+			audioFileId: audioFile.id,
+			lengthBeats: sec_to_beats(audioFile.duration),
+			offsetSeconds: 0,
+			gain: 1,
+		}
+	}
+
+	/**
+	 * Place a clip on the timeline.
+	 * @param customEndBeat — if provided, overrides the natural end beat (for magic brush grid trimming)
+	 */
+	function placeClip(startBeat: number, trackId: string, customEndBeat?: number): string | null {
+		const source = getBrushPlacementSource()
+		if (!source || !user.value || user.value.banned_at) return null
+
+		let endBeat = customEndBeat ?? startBeat + source.lengthBeats
+		endBeat = Math.min(endBeat, TOTAL_BEATS)
+
+		if (endBeat <= startBeat) return null
+
+		const tempId = `__temp__${nanoid()}`
+		const tempClip: Clip = {
+			id: tempId,
+			track_id: trackId,
+			audio_file_id: source.audioFileId,
+			creator_user_id: user.value.id,
+			creator_display_name: user.value.display_name,
+			start_beat: startBeat,
+			end_beat: endBeat,
+			offset_seconds: source.offsetSeconds,
+			gain: source.gain,
+			muted: false,
+			created_at: new Date().toISOString(),
+		}
+
+		clips.set(tempId, tempClip)
+
+		socket
+			.emitWithAck('get:clip:create', {
+				audio_file_id: source.audioFileId,
+				track_id: trackId,
+				start_beat: startBeat,
+				end_beat: endBeat,
+				offset_seconds: source.offsetSeconds,
+				gain: source.gain,
+				muted: false,
+			})
+			.then((res) => {
+				if (res.success) {
+					clips.delete(tempId)
+					clips.set(res.data.id, res.data)
+				} else {
+					userLog('SYSTEM', `Failed to place clip: ${res.error.message}`, {
+						textColor: 'red',
+					})
+					clips.delete(tempId)
+				}
+			})
+			.catch(() => {
+				clips.delete(tempId)
+			})
+
+		return tempId
+	}
+
+	function getClickPosition(
+		e: PointerEvent,
+	): { beat: number; trackId: string; topPx: number } | null {
+		if (!tracksWrapperEl.value) return null
+
+		const wrapperRect = tracksWrapperEl.value.getBoundingClientRect()
+
+		// Find which track we're over
+		const els = document.elementsFromPoint(e.clientX, e.clientY)
+		const trackEl = els.find((el) => el.classList.contains('track')) as HTMLElement | undefined
+
+		if (!trackEl) return null
+		const trackId = trackEl.dataset.trackId
+		if (!trackId) return null
+
+		// Calculate beat position
+		const relX = e.clientX - wrapperRect.left
+		const rawBeat = px_to_beats(relX)
+
+		const beat = altKeyPressed.value ? rawBeat : quantize_beats(rawBeat)
+
+		// Calculate topPx relative to wrapper
+		const trackRect = trackEl.getBoundingClientRect()
+		const topPx = trackRect.top - wrapperRect.top
+
+		return { beat: Math.max(0, beat), trackId, topPx }
+	}
+
+	/**
+	 * For magic brush: compute grid-step = quantize(durationBeats) rounded up to nearest grid unit.
+	 * This is the spacing between consecutive grid-placed clips.
+	 */
+	function getGridStep(): number {
+		const source = getBrushPlacementSource()
+		if (!source) return 1
+		// Round up to next grid unit (1 beat by default quantize)
+		return Math.max(1, Math.ceil(source.lengthBeats))
+	}
+
+	// Main handler — intercept pointerdown on tracks wrapper when brush active
+	useEventListener(
+		tracksWrapperEl,
+		'pointerdown',
+		(e) => {
+			if (!isBrushActive.value) return
+			if (controlKeyPressed.value) return // Allow Ctrl+click selection behavior to pass through to Index.vue
+			if (!brushAudioFileId.value) {
+				userLog(
+					'SYSTEM',
+					'No brush source selected. Drag from pool or click a clip in hand mode first.',
+					{
+						textColor: 'orange',
+					},
+				)
+				return
+			}
+			if (e.button !== 0) return
+			if (user.value?.banned_at) return
+
+			// Don't intercept if clicking on the timeline header
+			if ((e.target as HTMLElement).closest('.timeline-header-wrap')) return
+
+			e.preventDefault()
+			e.stopPropagation()
+
+			const pos = getClickPosition(e)
+			if (!pos) return
+
+			const source = getBrushPlacementSource()
+			if (!source) return
+			const durationBeats = source.lengthBeats
+
+			if (activeTool.value === 'magic-brush') {
+				// Magic brush: trim clip to fit grid
+				const gridStep = getGridStep()
+				const snappedStart = altKeyPressed.value
+					? pos.beat
+					: Math.floor(pos.beat / gridStep) * gridStep
+				const endBeat = snappedStart + gridStep // exact grid fit
+
+				const firstClipId = placeClip(snappedStart, pos.trackId, endBeat)
+				if (!firstClipId) return
+
+				brushDragState.value = {
+					trackId: pos.trackId,
+					nextRightBeat: snappedStart + gridStep,
+					nextLeftBeat: snappedStart - gridStep,
+					firstClipStartBeat: snappedStart,
+					direction: null,
+					placedClipIds: [firstClipId],
+				}
+			} else {
+				// Regular brush
+				const firstClipId = placeClip(pos.beat, pos.trackId)
+				if (!firstClipId) return
+
+				brushDragState.value = {
+					trackId: pos.trackId,
+					nextRightBeat: pos.beat + durationBeats,
+					nextLeftBeat: pos.beat - durationBeats,
+					firstClipStartBeat: pos.beat,
+					direction: null,
+					placedClipIds: [firstClipId],
+				}
+			}
+
+			const onMove = (me: PointerEvent) => {
+				if (!brushDragState.value || !tracksWrapperEl.value) return
+
+				me.preventDefault()
+
+				const movePos = getClickPosition(me)
+				if (!movePos) return
+
+				const source = getBrushPlacementSource()
+				if (!source) return
+				const durationBeats = source.lengthBeats
+
+				const state = brushDragState.value
+
+				// Determine direction on first move
+				if (state.direction === null) {
+					if (movePos.beat > state.firstClipStartBeat) {
+						state.direction = 'right'
+					} else if (movePos.beat < state.firstClipStartBeat) {
+						state.direction = 'left'
+					}
+				}
+
+				if (activeTool.value === 'brush') {
+					// --- BRUSH: consecutive placement ---
+					if (state.direction === 'right') {
+						// Place clips back-to-back rightward while mouse is past next position
+						while (
+							movePos.beat >= state.nextRightBeat &&
+							state.nextRightBeat < TOTAL_BEATS
+						) {
+							const clipId = placeClip(state.nextRightBeat, movePos.trackId)
+							if (clipId) {
+								state.placedClipIds.push(clipId)
+								state.nextRightBeat += durationBeats
+							} else {
+								break
+							}
+						}
+					} else if (state.direction === 'left') {
+						// Place clips leftward
+						while (movePos.beat <= state.nextLeftBeat && state.nextLeftBeat >= 0) {
+							const clipId = placeClip(state.nextLeftBeat, movePos.trackId)
+							if (clipId) {
+								state.placedClipIds.push(clipId)
+								state.nextLeftBeat -= durationBeats
+							} else {
+								break
+							}
+						}
+					}
+				} else if (activeTool.value === 'magic-brush') {
+					// --- MAGIC BRUSH: grid-snapped, trimmed to grid ---
+					const gridStep = getGridStep()
+
+					if (state.direction === 'right') {
+						while (
+							movePos.beat >= state.nextRightBeat &&
+							state.nextRightBeat < TOTAL_BEATS
+						) {
+							const endBeat = state.nextRightBeat + gridStep
+							const clipId = placeClip(state.nextRightBeat, movePos.trackId, endBeat)
+							if (clipId) {
+								state.placedClipIds.push(clipId)
+								state.nextRightBeat += gridStep
+							} else {
+								break
+							}
+						}
+					} else if (state.direction === 'left') {
+						while (movePos.beat <= state.nextLeftBeat && state.nextLeftBeat >= 0) {
+							const endBeat = state.nextLeftBeat + gridStep
+							const clipId = placeClip(state.nextLeftBeat, movePos.trackId, endBeat)
+							if (clipId) {
+								state.placedClipIds.push(clipId)
+								state.nextLeftBeat -= gridStep
+							} else {
+								break
+							}
+						}
+					}
+				}
+
+				brushDragState.value = { ...state }
+			}
+
+			const onUp = () => {
+				stopMove()
+				stopUp()
+				brushDragState.value = null
+			}
+
+			const stopMove = useEventListener(window, 'pointermove', onMove)
+			const stopUp = useEventListener(window, 'pointerup', onUp)
+		},
+		{ passive: false },
+	)
+
+	// --- Hover preview tracking ---
+	useEventListener(tracksWrapperEl, 'pointermove', (e) => {
+		if (!isBrushActive.value || brushDragState.value) {
+			brushPreview.visible = false
+			return
+		}
+		if (!brushAudioFileId.value) {
+			brushPreview.visible = false
+			return
+		}
+
+		const pos = getClickPosition(e)
+		if (!pos) {
+			brushPreview.visible = false
+			return
+		}
+
+		const source = getBrushPlacementSource()
+		if (!source) {
+			brushPreview.visible = false
+			return
+		}
+
+		const durationBeats = source.lengthBeats
+
+		let startBeat: number
+		let endBeat: number
+
+		if (activeTool.value === 'magic-brush') {
+			const gridStep = getGridStep()
+			startBeat = altKeyPressed.value ? pos.beat : Math.floor(pos.beat / gridStep) * gridStep
+			endBeat = startBeat + gridStep
+		} else {
+			startBeat = pos.beat
+			endBeat = startBeat + durationBeats
+		}
+
+		endBeat = Math.min(endBeat, TOTAL_BEATS)
+
+		brushPreview.visible = true
+		brushPreview.startBeat = startBeat
+		brushPreview.endBeat = endBeat
+		brushPreview.trackId = pos.trackId
+		brushPreview.topPx = pos.topPx
+	})
+
+	useEventListener(tracksWrapperEl, 'pointerleave', () => {
+		brushPreview.visible = false
+	})
+
+	// Hide preview during drag
+	watch(brushDragState, (state) => {
+		if (state) brushPreview.visible = false
+	})
+
+	// Set cursor when brush is active
+	watch(
+		isBrushActive,
+		(active) => {
+			if (active) {
+				document.body.style.cursor = 'crosshair'
+			} else {
+				document.body.style.cursor = ''
+				brushPreview.visible = false
+			}
+		},
+		{ immediate: true },
+	)
+
+	return { brushDragState, brushPreview }
+}

--- a/src/composables/useClipboardActions.ts
+++ b/src/composables/useClipboardActions.ts
@@ -67,7 +67,8 @@ export function useClipboardActions(options: ClipboardActionsOptions = {}) {
 	// --- PASTE ---
 	async function pasteClips() {
 		if (!clipboardClips.value || clipboardClips.value.length === 0) return
-		if (user.value?.banned_at) return
+		const currentUser = user.value
+		if (!currentUser || currentUser.banned_at) return
 
 		const entries = clipboardClips.value
 
@@ -89,30 +90,37 @@ export function useClipboardActions(options: ClipboardActionsOptions = {}) {
 		if (selectedClipIds.size > 0) {
 			const selectedTrackIndices = [...selectedClipIds]
 				.map((id) => clips.get(id))
-				.filter(Boolean)
-				.map((c) => getTrackIndex(c!.track_id))
-			baseTrackIndex = Math.min(...selectedTrackIndices)
+				.filter((clip): clip is Clip => clip != null)
+				.map((clip) => getTrackIndex(clip.track_id))
+				.filter((index) => index >= 0)
+			if (selectedTrackIndices.length > 0) {
+				baseTrackIndex = Math.min(...selectedTrackIndices)
+			}
 		}
 
 		const maxTrackIndex = sortedTrackIds.value.length - 1
+		if (maxTrackIndex < 0) return
 
-		// Clear selection and select pasted clips
-		selectedClipIds.clear()
-
-		const requests: Array<{
-			audio_file_id: string
-			track_id: string
-			start_beat: number
-			end_beat: number
-			offset_seconds: number
-			gain: number
-			muted: boolean
+		const placements: Array<{
+			request: {
+				audio_file_id: string
+				track_id: string
+				start_beat: number
+				end_beat: number
+				offset_seconds: number
+				gain: number
+				muted: boolean
+			}
+			tempClip: Clip
 		}> = []
 		const tempIds: string[] = []
 		let skippedOutOfBounds = 0
 
 		for (const entry of entries) {
-			const targetTrackIndex = Math.min(baseTrackIndex + entry.trackOffset, maxTrackIndex)
+			const targetTrackIndex = Math.max(
+				0,
+				Math.min(baseTrackIndex + entry.trackOffset, maxTrackIndex),
+			)
 			const targetTrackId = sortedTrackIds.value[targetTrackIndex]
 			if (!targetTrackId) continue
 
@@ -123,7 +131,7 @@ export function useClipboardActions(options: ClipboardActionsOptions = {}) {
 				continue
 			}
 
-			requests.push({
+			const request = {
 				audio_file_id: entry.audioFileId,
 				track_id: targetTrackId,
 				start_beat: startBeat,
@@ -131,16 +139,15 @@ export function useClipboardActions(options: ClipboardActionsOptions = {}) {
 				offset_seconds: entry.offsetSeconds,
 				gain: entry.gain,
 				muted: entry.muted ?? false,
-			})
+			}
 
-			// Optimistic temp clip
 			const tempId = `__temp__${nanoid()}`
 			const tempClip: Clip = {
 				id: tempId,
 				track_id: targetTrackId,
 				audio_file_id: entry.audioFileId,
-				creator_user_id: user.value!.id,
-				creator_display_name: user.value!.display_name,
+				creator_user_id: currentUser.id,
+				creator_display_name: currentUser.display_name,
 				start_beat: startBeat,
 				end_beat: endBeat,
 				offset_seconds: entry.offsetSeconds,
@@ -149,18 +156,27 @@ export function useClipboardActions(options: ClipboardActionsOptions = {}) {
 				created_at: new Date().toISOString(),
 			}
 
-			tempIds.push(tempId)
-			clips.set(tempId, tempClip)
-			selectedClipIds.add(tempId)
+			placements.push({ request, tempClip })
 		}
 
-		if (requests.length === 0) {
+		if (placements.length === 0) {
 			userLog('SYSTEM', 'Nothing pasted: clips would be outside timeline bounds.', {
 				textColor: 'orange',
 			})
 			return
 		}
 
+		const previousSelectionIds = [...selectedClipIds]
+		// Clear selection and select pasted clips
+		selectedClipIds.clear()
+
+		for (const { tempClip } of placements) {
+			tempIds.push(tempClip.id)
+			clips.set(tempClip.id, tempClip)
+			selectedClipIds.add(tempClip.id)
+		}
+
+		const requests = placements.map((placement) => placement.request)
 		const res = await socket.emitWithAck('get:clips:create:batch', { clips: requests })
 		let pastedCount = 0
 
@@ -180,6 +196,9 @@ export function useClipboardActions(options: ClipboardActionsOptions = {}) {
 				clips.delete(tempId)
 				selectedClipIds.delete(tempId)
 			}
+			for (const id of previousSelectionIds) {
+				if (clips.has(id)) selectedClipIds.add(id)
+			}
 			userLog('SYSTEM', `Failed to paste clips: ${res.error.message}`, {
 				textColor: 'red',
 			})
@@ -195,7 +214,8 @@ export function useClipboardActions(options: ClipboardActionsOptions = {}) {
 	// --- DUPLICATE ---
 	async function duplicateSelection() {
 		if (selectedClipIds.size === 0) return
-		if (user.value?.banned_at) return
+		const currentUser = user.value
+		if (!currentUser || currentUser.banned_at) return
 
 		const selected: Clip[] = []
 		for (const id of selectedClipIds) {
@@ -209,10 +229,19 @@ export function useClipboardActions(options: ClipboardActionsOptions = {}) {
 		const maxEnd = Math.max(...selected.map((c) => c.end_beat))
 		const selectionWidth = maxEnd - minBeat
 
-		// Clear current selection, will select duplicated clips
-		selectedClipIds.clear()
-
-		let queued = 0
+		const placements: Array<{
+			request: {
+				audio_file_id: string
+				track_id: string
+				start_beat: number
+				end_beat: number
+				offset_seconds: number
+				gain: number
+				muted: boolean
+			}
+			tempClip: Clip
+		}> = []
+		const tempIds: string[] = []
 		let skippedOutOfBounds = 0
 
 		for (const c of selected) {
@@ -223,13 +252,23 @@ export function useClipboardActions(options: ClipboardActionsOptions = {}) {
 				continue
 			}
 
+			const request = {
+				audio_file_id: c.audio_file_id,
+				track_id: c.track_id,
+				start_beat: startBeat,
+				end_beat: endBeat,
+				offset_seconds: c.offset_seconds,
+				gain: c.gain,
+				muted: c.muted,
+			}
+
 			const tempId = `__temp__${nanoid()}`
 			const tempClip: Clip = {
 				id: tempId,
 				track_id: c.track_id,
 				audio_file_id: c.audio_file_id,
-				creator_user_id: user.value!.id,
-				creator_display_name: user.value!.display_name,
+				creator_user_id: currentUser.id,
+				creator_display_name: currentUser.display_name,
 				start_beat: startBeat,
 				end_beat: endBeat,
 				offset_seconds: c.offset_seconds,
@@ -238,50 +277,60 @@ export function useClipboardActions(options: ClipboardActionsOptions = {}) {
 				created_at: new Date().toISOString(),
 			}
 
-			clips.set(tempId, tempClip)
-			selectedClipIds.add(tempId)
-			queued++
-
-			socket
-				.emitWithAck('get:clip:create', {
-					audio_file_id: c.audio_file_id,
-					track_id: c.track_id,
-					start_beat: startBeat,
-					end_beat: endBeat,
-					offset_seconds: c.offset_seconds,
-					gain: c.gain,
-					muted: c.muted,
-				})
-				.then((res) => {
-					if (res.success) {
-						clips.delete(tempId)
-						selectedClipIds.delete(tempId)
-						clips.set(res.data.id, res.data)
-						selectedClipIds.add(res.data.id)
-					} else {
-						userLog('SYSTEM', `Failed to duplicate clip: ${res.error.message}`, {
-							textColor: 'red',
-						})
-						clips.delete(tempId)
-						selectedClipIds.delete(tempId)
-					}
-				})
-				.catch(() => {
-					clips.delete(tempId)
-					selectedClipIds.delete(tempId)
-				})
+			placements.push({ request, tempClip })
 		}
 
-		if (queued === 0) {
+		if (placements.length === 0) {
 			userLog('SYSTEM', 'Nothing duplicated: clips would be outside timeline bounds.', {
 				textColor: 'orange',
 			})
 			return
 		}
 
+		const previousSelectionIds = [...selectedClipIds]
+		selectedClipIds.clear()
+
+		for (const { tempClip } of placements) {
+			tempIds.push(tempClip.id)
+			clips.set(tempClip.id, tempClip)
+			selectedClipIds.add(tempClip.id)
+		}
+
+		const requests = placements.map((placement) => placement.request)
+		const res = await socket.emitWithAck('get:clips:create:batch', { clips: requests })
+		let duplicatedCount = 0
+
+		if (res.success) {
+			for (const tempId of tempIds) {
+				clips.delete(tempId)
+				selectedClipIds.delete(tempId)
+			}
+
+			for (const clip of res.data) {
+				clips.set(clip.id, clip)
+				selectedClipIds.add(clip.id)
+			}
+			duplicatedCount = res.data.length
+		} else {
+			for (const tempId of tempIds) {
+				clips.delete(tempId)
+				selectedClipIds.delete(tempId)
+			}
+			for (const id of previousSelectionIds) {
+				if (clips.has(id)) selectedClipIds.add(id)
+			}
+			userLog('SYSTEM', `Failed to duplicate clips: ${res.error.message}`, {
+				textColor: 'red',
+			})
+		}
+
 		const skippedMsg =
 			skippedOutOfBounds > 0 ? ` (${skippedOutOfBounds} skipped out of bounds)` : ''
-		userLog('SYSTEM', `Duplicated ${queued} clip(s)${skippedMsg}`, { textColor: 'cyan' })
+		if (duplicatedCount > 0) {
+			userLog('SYSTEM', `Duplicated ${duplicatedCount} clip(s)${skippedMsg}`, {
+				textColor: 'cyan',
+			})
+		}
 	}
 
 	// --- DELETE ---

--- a/src/composables/useClipboardActions.ts
+++ b/src/composables/useClipboardActions.ts
@@ -1,0 +1,369 @@
+import { useEventListener } from '@vueuse/core'
+import { computed } from 'vue'
+import {
+	clips,
+	selectedClipIds,
+	clipboardClips,
+	tracks,
+	user,
+	TOTAL_BEATS,
+	type ClipboardEntry,
+} from '@/state'
+import { currentPlayTimeBeats } from '@/audioEngine'
+import { quantize_beats } from '@/utils/mathUtils'
+import { socket } from '@/socket/socket'
+import { useConsole } from '@/composables/useConsole'
+import { nanoid } from 'nanoid'
+import type { Clip } from '~/schema'
+
+type ClipboardActionsOptions = {
+	bindKeyboard?: boolean
+}
+
+export function useClipboardActions(options: ClipboardActionsOptions = {}) {
+	const { userLog } = useConsole()
+	const { bindKeyboard = true } = options
+
+	// Sorted tracks for index-based track offset lookup
+	const sortedTrackIds = computed(() =>
+		[...tracks.entries()].sort((a, b) => a[1].order_index - b[1].order_index).map(([id]) => id),
+	)
+
+	function getTrackIndex(trackId: string): number {
+		return sortedTrackIds.value.indexOf(trackId)
+	}
+
+	// --- COPY ---
+	function copySelection() {
+		if (selectedClipIds.size === 0) return
+		if (user.value?.banned_at) return
+
+		const selected: Clip[] = []
+		for (const id of selectedClipIds) {
+			const clip = clips.get(id)
+			if (clip) selected.push(clip)
+		}
+		if (selected.length === 0) return
+
+		// Find leftmost beat and lowest track index
+		const minBeat = Math.min(...selected.map((c) => c.start_beat))
+		const trackIndices = selected.map((c) => getTrackIndex(c.track_id))
+		const minTrackIndex = Math.min(...trackIndices)
+
+		const entries: ClipboardEntry[] = selected.map((c) => ({
+			relStartBeat: c.start_beat - minBeat,
+			relEndBeat: c.end_beat - minBeat,
+			trackOffset: getTrackIndex(c.track_id) - minTrackIndex,
+			audioFileId: c.audio_file_id,
+			offsetSeconds: c.offset_seconds,
+			gain: c.gain,
+			muted: c.muted,
+		}))
+
+		clipboardClips.value = entries
+		userLog('SYSTEM', `Copied ${entries.length} clip(s)`, { textColor: 'cyan' })
+	}
+
+	// --- PASTE ---
+	async function pasteClips() {
+		if (!clipboardClips.value || clipboardClips.value.length === 0) return
+		if (user.value?.banned_at) return
+
+		const entries = clipboardClips.value
+
+		// Determine paste position: use playhead if > 0, else after selection, else beat 0
+		let pasteAtBeat = quantize_beats(currentPlayTimeBeats.value)
+
+		if (pasteAtBeat <= 0 && selectedClipIds.size > 0) {
+			// Paste after rightmost selected clip
+			let maxEnd = 0
+			for (const id of selectedClipIds) {
+				const c = clips.get(id)
+				if (c && c.end_beat > maxEnd) maxEnd = c.end_beat
+			}
+			pasteAtBeat = quantize_beats(maxEnd)
+		}
+
+		// Determine target base track index
+		let baseTrackIndex = 0
+		if (selectedClipIds.size > 0) {
+			const selectedTrackIndices = [...selectedClipIds]
+				.map((id) => clips.get(id))
+				.filter(Boolean)
+				.map((c) => getTrackIndex(c!.track_id))
+			baseTrackIndex = Math.min(...selectedTrackIndices)
+		}
+
+		const maxTrackIndex = sortedTrackIds.value.length - 1
+
+		// Clear selection and select pasted clips
+		selectedClipIds.clear()
+
+		const requests: Array<{
+			audio_file_id: string
+			track_id: string
+			start_beat: number
+			end_beat: number
+			offset_seconds: number
+			gain: number
+			muted: boolean
+		}> = []
+		const tempIds: string[] = []
+		let skippedOutOfBounds = 0
+
+		for (const entry of entries) {
+			const targetTrackIndex = Math.min(baseTrackIndex + entry.trackOffset, maxTrackIndex)
+			const targetTrackId = sortedTrackIds.value[targetTrackIndex]
+			if (!targetTrackId) continue
+
+			const startBeat = Math.max(0, pasteAtBeat + entry.relStartBeat)
+			const endBeat = Math.min(TOTAL_BEATS, pasteAtBeat + entry.relEndBeat)
+			if (endBeat <= startBeat) {
+				skippedOutOfBounds++
+				continue
+			}
+
+			requests.push({
+				audio_file_id: entry.audioFileId,
+				track_id: targetTrackId,
+				start_beat: startBeat,
+				end_beat: endBeat,
+				offset_seconds: entry.offsetSeconds,
+				gain: entry.gain,
+				muted: entry.muted ?? false,
+			})
+
+			// Optimistic temp clip
+			const tempId = `__temp__${nanoid()}`
+			const tempClip: Clip = {
+				id: tempId,
+				track_id: targetTrackId,
+				audio_file_id: entry.audioFileId,
+				creator_user_id: user.value!.id,
+				creator_display_name: user.value!.display_name,
+				start_beat: startBeat,
+				end_beat: endBeat,
+				offset_seconds: entry.offsetSeconds,
+				gain: entry.gain,
+				muted: entry.muted ?? false,
+				created_at: new Date().toISOString(),
+			}
+
+			tempIds.push(tempId)
+			clips.set(tempId, tempClip)
+			selectedClipIds.add(tempId)
+		}
+
+		if (requests.length === 0) {
+			userLog('SYSTEM', 'Nothing pasted: clips would be outside timeline bounds.', {
+				textColor: 'orange',
+			})
+			return
+		}
+
+		const res = await socket.emitWithAck('get:clips:create:batch', { clips: requests })
+		let pastedCount = 0
+
+		if (res.success) {
+			for (const tempId of tempIds) {
+				clips.delete(tempId)
+				selectedClipIds.delete(tempId)
+			}
+
+			for (const clip of res.data) {
+				clips.set(clip.id, clip)
+				selectedClipIds.add(clip.id)
+			}
+			pastedCount = res.data.length
+		} else {
+			for (const tempId of tempIds) {
+				clips.delete(tempId)
+				selectedClipIds.delete(tempId)
+			}
+			userLog('SYSTEM', `Failed to paste clips: ${res.error.message}`, {
+				textColor: 'red',
+			})
+		}
+
+		if (pastedCount > 0) {
+			const skippedMsg =
+				skippedOutOfBounds > 0 ? ` (${skippedOutOfBounds} skipped out of bounds)` : ''
+			userLog('SYSTEM', `Pasted ${pastedCount} clip(s)${skippedMsg}`, { textColor: 'cyan' })
+		}
+	}
+
+	// --- DUPLICATE ---
+	async function duplicateSelection() {
+		if (selectedClipIds.size === 0) return
+		if (user.value?.banned_at) return
+
+		const selected: Clip[] = []
+		for (const id of selectedClipIds) {
+			const clip = clips.get(id)
+			if (clip) selected.push(clip)
+		}
+		if (selected.length === 0) return
+
+		// Width of selection = rightmost end - leftmost start
+		const minBeat = Math.min(...selected.map((c) => c.start_beat))
+		const maxEnd = Math.max(...selected.map((c) => c.end_beat))
+		const selectionWidth = maxEnd - minBeat
+
+		// Clear current selection, will select duplicated clips
+		selectedClipIds.clear()
+
+		let queued = 0
+		let skippedOutOfBounds = 0
+
+		for (const c of selected) {
+			const startBeat = Math.max(0, c.start_beat + selectionWidth)
+			const endBeat = Math.min(TOTAL_BEATS, c.end_beat + selectionWidth)
+			if (endBeat <= startBeat) {
+				skippedOutOfBounds++
+				continue
+			}
+
+			const tempId = `__temp__${nanoid()}`
+			const tempClip: Clip = {
+				id: tempId,
+				track_id: c.track_id,
+				audio_file_id: c.audio_file_id,
+				creator_user_id: user.value!.id,
+				creator_display_name: user.value!.display_name,
+				start_beat: startBeat,
+				end_beat: endBeat,
+				offset_seconds: c.offset_seconds,
+				gain: c.gain,
+				muted: c.muted,
+				created_at: new Date().toISOString(),
+			}
+
+			clips.set(tempId, tempClip)
+			selectedClipIds.add(tempId)
+			queued++
+
+			socket
+				.emitWithAck('get:clip:create', {
+					audio_file_id: c.audio_file_id,
+					track_id: c.track_id,
+					start_beat: startBeat,
+					end_beat: endBeat,
+					offset_seconds: c.offset_seconds,
+					gain: c.gain,
+					muted: c.muted,
+				})
+				.then((res) => {
+					if (res.success) {
+						clips.delete(tempId)
+						selectedClipIds.delete(tempId)
+						clips.set(res.data.id, res.data)
+						selectedClipIds.add(res.data.id)
+					} else {
+						userLog('SYSTEM', `Failed to duplicate clip: ${res.error.message}`, {
+							textColor: 'red',
+						})
+						clips.delete(tempId)
+						selectedClipIds.delete(tempId)
+					}
+				})
+				.catch(() => {
+					clips.delete(tempId)
+					selectedClipIds.delete(tempId)
+				})
+		}
+
+		if (queued === 0) {
+			userLog('SYSTEM', 'Nothing duplicated: clips would be outside timeline bounds.', {
+				textColor: 'orange',
+			})
+			return
+		}
+
+		const skippedMsg =
+			skippedOutOfBounds > 0 ? ` (${skippedOutOfBounds} skipped out of bounds)` : ''
+		userLog('SYSTEM', `Duplicated ${queued} clip(s)${skippedMsg}`, { textColor: 'cyan' })
+	}
+
+	// --- DELETE ---
+	async function deleteSelection() {
+		if (selectedClipIds.size === 0) return
+		if (user.value?.banned_at) return
+
+		const idsToDelete = [...selectedClipIds]
+		selectedClipIds.clear()
+
+		let deleted = 0
+		for (const id of idsToDelete) {
+			const clip = clips.get(id)
+			if (!clip) continue
+
+			// Optimistic delete
+			clips.delete(id)
+			if (id.startsWith('__temp__')) {
+				deleted++
+				continue
+			}
+
+			socket
+				.emitWithAck('get:clip:delete', { id })
+				.then((res) => {
+					if (!res.success) {
+						const message = res.error?.message ?? ''
+						if (message.includes('Failed to delete clip')) return
+
+						// Re-add if failed
+						if (clip) clips.set(id, clip)
+						userLog('SYSTEM', `Failed to delete clip: ${message}`, {
+							textColor: 'red',
+						})
+					}
+				})
+				.catch(() => {
+					if (clip) clips.set(id, clip)
+				})
+
+			deleted++
+		}
+
+		userLog('SYSTEM', `Deleted ${deleted} clip(s)`, { textColor: 'cyan' })
+	}
+
+	// --- Keyboard bindings ---
+	if (bindKeyboard) {
+		useEventListener(window, 'keydown', (e) => {
+			// Don't intercept when typing in inputs
+			const tag = (e.target as HTMLElement).tagName
+			if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+
+			const ctrl = e.ctrlKey || e.metaKey
+			const key = e.key.toLowerCase()
+
+			if (ctrl && key === 'c') {
+				e.preventDefault()
+				copySelection()
+				return
+			}
+
+			if (ctrl && key === 'v') {
+				e.preventDefault()
+				pasteClips()
+				return
+			}
+
+			if (ctrl && key === 'd') {
+				e.preventDefault()
+				duplicateSelection()
+				return
+			}
+
+			if (key === 'delete' || key === 'backspace') {
+				// Don't delete if focused on an input
+				e.preventDefault()
+				deleteSelection()
+				return
+			}
+		})
+	}
+
+	return { copySelection, pasteClips, duplicateSelection, deleteSelection }
+}

--- a/src/socket/eventHandlers/clip_delete.ts
+++ b/src/socket/eventHandlers/clip_delete.ts
@@ -1,9 +1,10 @@
 import { defineSocketHandler } from '@/socket/socket'
-import { clips } from '@/state'
+import { clips, selectedClipIds } from '@/state'
 
 export default defineSocketHandler({
 	event: 'clip:delete',
 	handler: (id) => {
 		clips.delete(id)
+		selectedClipIds.delete(id)
 	},
 })

--- a/src/state.ts
+++ b/src/state.ts
@@ -11,6 +11,43 @@ import { type DebugEntry } from '@/composables/useDebug'
 import { useDevicePixelRatio, useEventListener, useIntervalFn, useTimeoutFn } from '@vueuse/core'
 import type { AudioFile } from '@/types'
 
+// --- Clipboard & Tool types ---
+
+export type ToolMode = 'hand' | 'brush' | 'magic-brush' | 'slice' | 'mute'
+
+export type ClipboardEntry = {
+	relStartBeat: number
+	relEndBeat: number
+	trackOffset: number // index delta from lowest track in selection
+	audioFileId: string
+	offsetSeconds: number
+	gain: number
+	muted: boolean
+}
+
+export type BrushSourceClip = {
+	audioFileId: string
+	lengthBeats: number
+	offsetSeconds: number
+	gain: number
+}
+
+export type MultiDragState = {
+	startX: number
+	startY: number
+	deltaBeats: number
+	trackDelta: number
+	sourceClipId: string
+	clipSnapshots: Map<
+		string,
+		{
+			origStartBeat: number
+			origEndBeat: number
+			origTrackId: string
+		}
+	>
+}
+
 export const user = ref<User | null>(null)
 export const client = ref<Client | null>(null)
 export const showAdminPanel = shallowRef(false)
@@ -41,6 +78,35 @@ export const dragFromPoolState = shallowRef<{
 	clientX: number
 	clientY: number
 } | null>(null)
+
+// --- Tool & Clipboard state ---
+export const activeTool = shallowRef<ToolMode>('hand')
+export const brushAudioFileId = shallowRef<string | null>(null)
+export const brushSourceClip = shallowRef<BrushSourceClip | null>(null)
+export const audioPoolPreviewOnClick = shallowRef(false)
+export const cloneDragPreview = reactive<{
+	visible: boolean
+	trackId: string | null
+	audioFileId: string | null
+	startBeat: number
+	endBeat: number
+	offsetSeconds: number
+	gain: number
+	muted: boolean
+	topPx: number
+}>({
+	visible: false,
+	trackId: null,
+	audioFileId: null,
+	startBeat: 0,
+	endBeat: 0,
+	offsetSeconds: 0,
+	gain: 1,
+	muted: false,
+	topPx: 0,
+})
+export const clipboardClips = shallowRef<ClipboardEntry[] | null>(null)
+export const multiDragState = shallowRef<MultiDragState | null>(null)
 
 export const TOTAL_BEATS = 16 * 16
 export const pxPerBeat = shallowRef(40)
@@ -74,6 +140,10 @@ useEventListener(window, 'pointerup', (event) => {
 	if (event.button === 2) {
 		rightMouseButtonPressedOnTimeline.value = false
 	}
+})
+
+useEventListener(window, 'blur', () => {
+	rightMouseButtonPressedOnTimeline.value = false
 })
 
 watchEffect(() => {

--- a/src/utils/offlineRenderer.ts
+++ b/src/utils/offlineRenderer.ts
@@ -70,6 +70,8 @@ export async function renderPlaylistOffline(): Promise<AudioBuffer> {
 
 	// Schedule every clip
 	for (const clip of snapshot.clips) {
+		if (clip.muted) continue
+
 		const buffer = snapshot.buffers.get(clip.audio_file_id)
 		const trackGainNode = trackGainNodes.get(clip.track_id)
 		if (!buffer || !trackGainNode) continue

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -77,6 +77,8 @@
 				style="width: 80px; margin-left: 1rem"
 			/>
 
+			<Toolbar />
+
 			<div style="flex-grow: 1"></div>
 
 			<button
@@ -128,6 +130,40 @@
 						zIndex: 10,
 						pointerEvents: 'none',
 						opacity: 0.7,
+					}"
+				/>
+
+				<!-- Brush hover preview -->
+				<ClipInstance
+					v-if="brushPreviewClip && brushPreviewAudioFile && brushPreview.visible"
+					:audiofile="brushPreviewAudioFile"
+					:clip="brushPreviewClip"
+					:style="{
+						position: 'absolute',
+						height: `${pxTrackHeight}px`,
+						top: `${brushPreview.topPx}px`,
+						zIndex: 10,
+						pointerEvents: 'none',
+						opacity: 0.4,
+					}"
+				/>
+
+				<!-- Shift clone drag preview -->
+				<ClipInstance
+					v-if="
+						cloneDragPreviewClip &&
+						cloneDragPreviewAudioFile &&
+						cloneDragPreview.visible
+					"
+					:audiofile="cloneDragPreviewAudioFile"
+					:clip="cloneDragPreviewClip"
+					:style="{
+						position: 'absolute',
+						height: `${pxTrackHeight}px`,
+						top: `${cloneDragPreview.topPx}px`,
+						zIndex: 10,
+						pointerEvents: 'none',
+						opacity: 0.45,
 					}"
 				/>
 
@@ -233,6 +269,10 @@ import {
 	bpm,
 	selectedClipIds,
 	showAdminPanel,
+	activeTool,
+	brushAudioFileId,
+	brushSourceClip,
+	rightMouseButtonPressedOnTimeline,
 } from '@/state'
 import TrackInstance from '@/components/tracks/TrackInstance.vue'
 import {
@@ -265,6 +305,7 @@ import {
 	altKeyPressed,
 	audiofiles,
 	clips,
+	cloneDragPreview,
 	dragFromPoolState,
 	pxTrackHeight,
 	TOTAL_BEATS,
@@ -294,6 +335,9 @@ import GlobalLoadingIndicator from '@/components/GlobalLoadingIndicator.vue'
 import { nanoid } from 'nanoid'
 import CustomMenuIcon from '@/components/CustomMenuIcon.vue'
 import { useConsole } from '@/composables/useConsole'
+import { useClipboardActions } from '@/composables/useClipboardActions'
+import { useBrushTool } from '@/composables/useBrushTool'
+import Toolbar from '@/components/Toolbar.vue'
 import AdminUserList from '@/components/AdminUserList.vue'
 import { renderPlaylistOffline } from '@/utils/offlineRenderer'
 import { encodeWav, encodeMp3 } from '@/utils/encoders'
@@ -497,6 +541,253 @@ function updateDims() {
 const tracksWrapperEl = useTemplateRef('tracksWrapper')
 const tracksContainerInnerEl = useTemplateRef('tracksContainerInner')
 useResizeObserver(tracksWrapperEl, updateDims)
+
+// Clipboard & Brush tools
+useClipboardActions()
+const { brushPreview } = useBrushTool(tracksWrapperEl)
+
+const brushPreviewAudioFile = computed(() => {
+	if (!brushPreview.visible || !brushPreview.trackId) return null
+	if (!brushAudioFileId.value) return null
+	return audiofiles.get(brushAudioFileId.value) ?? null
+})
+
+const brushPreviewClip = computed<Clip | null>(() => {
+	if (!brushPreviewAudioFile.value || !brushPreview.visible || !brushPreview.trackId) return null
+	const previewUsesCustomSource =
+		brushSourceClip.value &&
+		brushSourceClip.value.audioFileId === brushPreviewAudioFile.value.id
+
+	return {
+		id: '__brush_preview__',
+		track_id: brushPreview.trackId,
+		audio_file_id: brushPreviewAudioFile.value.id,
+		creator_user_id: 'preview',
+		creator_display_name: '',
+		start_beat: brushPreview.startBeat,
+		end_beat: brushPreview.endBeat,
+		offset_seconds: previewUsesCustomSource
+			? Math.max(0, brushSourceClip.value!.offsetSeconds)
+			: 0,
+		gain: previewUsesCustomSource ? brushSourceClip.value!.gain : 1,
+		muted: false,
+		created_at: new Date().toISOString(),
+	}
+})
+
+const cloneDragPreviewAudioFile = computed(() => {
+	if (!cloneDragPreview.visible || !cloneDragPreview.trackId || !cloneDragPreview.audioFileId)
+		return null
+	return audiofiles.get(cloneDragPreview.audioFileId) ?? null
+})
+
+const cloneDragPreviewClip = computed<Clip | null>(() => {
+	if (
+		!cloneDragPreview.visible ||
+		!cloneDragPreview.trackId ||
+		!cloneDragPreviewAudioFile.value
+	) {
+		return null
+	}
+
+	return {
+		id: '__clone_drag_preview__',
+		track_id: cloneDragPreview.trackId,
+		audio_file_id: cloneDragPreviewAudioFile.value.id,
+		creator_user_id: 'preview',
+		creator_display_name: '',
+		start_beat: cloneDragPreview.startBeat,
+		end_beat: cloneDragPreview.endBeat,
+		offset_seconds: Math.max(0, cloneDragPreview.offsetSeconds),
+		gain: cloneDragPreview.gain,
+		muted: cloneDragPreview.muted,
+		created_at: new Date().toISOString(),
+	}
+})
+
+const pendingRightSwipeDeleteIds = new Set<string>()
+const lastRightSwipePoint = shallowRef<{ x: number; y: number } | null>(null)
+
+function collectClipIdsAtPoint(x: number, y: number, ids: Set<string>) {
+	const els = document.elementsFromPoint(Math.round(x), Math.round(y))
+	for (const el of els) {
+		if (!(el instanceof HTMLElement)) continue
+		const clipEl = el.closest('.clip') as HTMLElement | null
+		if (!clipEl) continue
+		const clipId = clipEl.dataset.clipId
+		if (!clipId || clipId === '__brush_preview__' || clipId === '__clone_drag_preview__')
+			continue
+		ids.add(clipId)
+	}
+}
+
+function collectClipIdsAlongSegment(
+	from: { x: number; y: number },
+	to: { x: number; y: number },
+): Set<string> {
+	const ids = new Set<string>()
+	const dx = to.x - from.x
+	const dy = to.y - from.y
+	const dist = Math.hypot(dx, dy)
+	const steps = Math.max(1, Math.ceil(dist / 8))
+
+	for (let i = 0; i <= steps; i++) {
+		const t = i / steps
+		collectClipIdsAtPoint(from.x + dx * t, from.y + dy * t, ids)
+	}
+
+	return ids
+}
+
+async function deleteClipByRightSwipe(clipId: string) {
+	if (pendingRightSwipeDeleteIds.has(clipId)) return
+	const clip = clips.get(clipId)
+	if (!clip) return
+
+	const wasSelected = selectedClipIds.has(clipId)
+	pendingRightSwipeDeleteIds.add(clipId)
+	selectedClipIds.delete(clipId)
+	clips.delete(clipId)
+
+	if (clipId.startsWith('__temp__')) {
+		pendingRightSwipeDeleteIds.delete(clipId)
+		return
+	}
+
+	const res = await socket.emitWithAck('get:clip:delete', { id: clipId })
+	if (!res.success) {
+		const message = res.error?.message ?? ''
+		// Idempotent behavior for races: another delete path may have removed it first.
+		if (message.includes('Failed to delete clip')) {
+			pendingRightSwipeDeleteIds.delete(clipId)
+			return
+		}
+
+		clips.set(clipId, clip)
+		if (wasSelected) selectedClipIds.add(clipId)
+		userLog('SYSTEM', `Failed to delete clip: ${message}`, {
+			textColor: 'red',
+		})
+	}
+
+	pendingRightSwipeDeleteIds.delete(clipId)
+}
+
+async function setClipMutedState(clipId: string, muted: boolean) {
+	if (user.value?.banned_at) return
+	const clip = clips.get(clipId)
+	if (!clip) return
+	if (clip.muted === muted) return
+
+	const previousMuted = clip.muted
+	clip.muted = muted
+
+	if (clip.id.startsWith('__temp__')) return
+
+	const res = await socket.emitWithAck('get:clip:update', {
+		id: clip.id,
+		changes: {
+			muted,
+		},
+	})
+
+	if (!res.success) {
+		const current = clips.get(clipId)
+		if (current && current.muted === muted) {
+			current.muted = previousMuted
+		}
+		userLog('SYSTEM', `Failed to mute clip: ${res.error.message}`, {
+			textColor: 'red',
+		})
+		return
+	}
+
+	const current = clips.get(clipId)
+	if (current) {
+		current.muted = res.data.muted ?? muted
+	}
+}
+
+useEventListener(tracksWrapperEl, 'pointerdown', (e) => {
+	if (activeTool.value !== 'mute') return
+	if (e.button !== 0) return
+	if (controlKeyPressed.value) return
+	if (user.value?.banned_at) return
+
+	const target = e.target as HTMLElement
+	if (target.closest('.timeline-header-wrap')) return
+
+	e.preventDefault()
+
+	const processedClipIds = new Set<string>()
+	let targetMuted: boolean | null = null
+	let lastPoint = { x: e.clientX, y: e.clientY }
+
+	const applyClipMute = (clipId: string) => {
+		if (processedClipIds.has(clipId)) return
+		const clip = clips.get(clipId)
+		if (!clip) return
+
+		processedClipIds.add(clipId)
+		if (targetMuted === null) {
+			targetMuted = !clip.muted
+		}
+		if (targetMuted === null) return
+
+		void setClipMutedState(clipId, targetMuted)
+	}
+
+	const initialClipIds = collectClipIdsAlongSegment(lastPoint, lastPoint)
+	for (const clipId of initialClipIds) {
+		applyClipMute(clipId)
+	}
+
+	const onMove = (me: PointerEvent) => {
+		const currentPoint = { x: me.clientX, y: me.clientY }
+		const clipIds = collectClipIdsAlongSegment(lastPoint, currentPoint)
+		for (const clipId of clipIds) {
+			applyClipMute(clipId)
+		}
+		lastPoint = currentPoint
+	}
+
+	const onUp = () => {
+		stopMove()
+		stopUp()
+	}
+
+	const stopMove = useEventListener(window, 'pointermove', onMove)
+	const stopUp = useEventListener(window, 'pointerup', onUp)
+})
+
+useEventListener(window, 'pointerdown', (e) => {
+	if (e.button !== 2) return
+	lastRightSwipePoint.value = { x: e.clientX, y: e.clientY }
+})
+
+useEventListener(window, 'pointerup', (e) => {
+	if (e.button !== 2) return
+	lastRightSwipePoint.value = null
+})
+
+useEventListener(window, 'blur', () => {
+	lastRightSwipePoint.value = null
+})
+
+useEventListener(window, 'pointermove', (e) => {
+	if (!rightMouseButtonPressedOnTimeline.value) return
+	if ((e.buttons & 2) === 0) return
+	if (user.value?.banned_at) return
+
+	const currentPoint = { x: e.clientX, y: e.clientY }
+	const previousPoint = lastRightSwipePoint.value ?? currentPoint
+	const clipIds = collectClipIdsAlongSegment(previousPoint, currentPoint)
+	for (const clipId of clipIds) {
+		void deleteClipByRightSwipe(clipId)
+	}
+
+	lastRightSwipePoint.value = currentPoint
+})
 
 // Cursor Logic
 // todo: should be moved to trackinstance for better performance bc it will allow direct access to .track which here i have to get through the target.closest....
@@ -775,6 +1066,7 @@ const ghostClip = computed<Clip | null>(() => {
 		end_beat: ghostDragState.value.end_beat,
 		offset_seconds: 0,
 		gain: 1,
+		muted: false,
 		created_at: new Date().toISOString(),
 		// peaks: ghostAudioFile.value.peaks // Clip doesn't have peaks, AudioFile does.
 	}
@@ -789,6 +1081,10 @@ watch(
 			// If we want to add/remove listeners:
 			return
 		}
+
+		// Auto-set brush audio file when dragging from pool
+		brushAudioFileId.value = dragState.audioFileId
+		brushSourceClip.value = null
 
 		ghostDragState.value = {
 			start_beat: 0,
@@ -879,6 +1175,7 @@ watch(
 					end_beat: state.end_beat,
 					offset_seconds: 0,
 					gain: 1,
+					muted: false,
 					created_at: new Date().toISOString(),
 				}
 
@@ -902,6 +1199,7 @@ watch(
 						end_beat: currentClip.end_beat,
 						offset_seconds: currentClip.offset_seconds,
 						gain: currentClip.gain,
+						muted: currentClip.muted,
 					})
 
 					if (res.success) {
@@ -968,6 +1266,9 @@ useEventListener(tracksWrapperEl, 'pointerdown', (e) => {
 
 	// Don't interact if clicking on the timeline header (e.g. for loop controls)
 	if ((e.target as HTMLElement).closest('.timeline-header-wrap')) return
+
+	// Brush tools handle their own pointerdown, unless we are holding Ctrl to select
+	if (activeTool.value !== 'hand' && !controlKeyPressed.value) return
 
 	// Clear selection if clicking on empty space without Control key (Left or Right Click)
 	if (!controlKeyPressed.value && (e.button === 0 || e.button === 2)) {


### PR DESCRIPTION
## Summary
- add clipboard workflows (`copy`, `paste`, `duplicate`, `delete`) with keyboard shortcuts and menu actions
- make paste behavior contextual:
  - paste at the playhead/cursor position
  - if cursor is at start, paste after the current selection
- improve multi-selection:
  - fix moving multiple selected clips at once
  - ensure multi-selection is fully compatible with copy/paste/duplicate
- add timeline loop-range creation via right-click drag
- add clip cloning with the `Hand` tool while holding `Shift`
- add sample preview on click in the Audio Pool
- add tool system (`hand`, `brush`, `magic-brush`, `slice`, `mute`) with toolbar integration
- add batch clip creation API + undo history support
- add end-to-end muted clip support (schema, DB, engine, offline render)
- improve timeline/clip pointer interactions and drag state handling
- add optimistic rollback safeguards for clip move/update failures

Closes #29  (Preview button on/off sample pool).
Closes #56  (Same as #29).
Closes #30 (mutli clip editing i guess?).
Closes #33 (copy pasta and stuff).
Maybe Closes #48  (Slice tool might close this?).
Maybe Closes #57  (Mute tool might close this?).

## Validation
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run format`

Work complete, boss. I can finally go to sleep now.
