### PR TITLE
feat: Add playhead tracking feature with 'F' key shortcut, UI toggle,…

### DIFF
--- a/src/components/TimelineHeader.vue
+++ b/src/components/TimelineHeader.vue
@@ -104,6 +104,12 @@ const playheadStyle = computed((): CSSProperties => {
 	}
 })
 
+function snapToDevicePixel(px: number) {
+	const dpr =
+		typeof window !== 'undefined' && window.devicePixelRatio > 0 ? window.devicePixelRatio : 1
+	return Math.round(px * dpr) / dpr
+}
+
 const playheadHeadStyle = computed((): CSSProperties => {
 	return {
 		transform: `translateX(${playHeadPosPx.value}px) translateX(-50%)`,
@@ -117,14 +123,15 @@ const restingPlayheadStyle = computed((): CSSProperties => {
 })
 
 const restingPosPx = computed(() => {
-	return beats_to_px(sec_to_beats(restingPositionSec.value))
+	return snapToDevicePixel(beats_to_px(sec_to_beats(restingPositionSec.value)))
 })
 
 const localPlayheadBeat = shallowRef<number | null>(null)
 
 const playHeadPosPx = computed(() => {
-	if (localPlayheadBeat.value != null) return beats_to_px(localPlayheadBeat.value)
-	return beats_to_px(sec_to_beats(currentTime.value))
+	if (localPlayheadBeat.value != null)
+		return snapToDevicePixel(beats_to_px(localPlayheadBeat.value))
+	return snapToDevicePixel(beats_to_px(sec_to_beats(currentTime.value)))
 })
 
 const isActionKeyPressed = computed(() => controlKeyPressed.value || shiftKeyPressed.value)
@@ -352,6 +359,11 @@ watchThrottled(
 
 .playhead-line.is-playing {
 	background-color: var(--active-playing-color);
+}
+
+.playhead-line.is-playing,
+.playhead-head.is-playing {
+	transition: none;
 }
 
 .playhead-line.is-playing::before {

--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -56,6 +56,13 @@
 					<p class="kbd" :class="{ active: lKeyPressed }">L</p>
 				</div>
 			</button>
+			<button class="default-button menu-btn" @click="emits('onTogglePlayheadTracking')">
+				<ArrowRightToLine class="dim" :size="14" :stroke-width="2" />
+				<p>{{ isPlayheadTracking ? 'Disable' : 'Enable' }} Tracking</p>
+				<div class="shortcut-container mono">
+					<p class="kbd" :class="{ active: fKeyPressed }">F</p>
+				</div>
+			</button>
 
 			<div
 				style="
@@ -177,7 +184,14 @@
 
 <script setup lang="ts">
 import { socket } from '@/socket/socket'
-import { user, controlKeyPressed, zKeyPressed, tKeyPressed, lKeyPressed } from '@/state'
+import {
+	user,
+	controlKeyPressed,
+	zKeyPressed,
+	tKeyPressed,
+	fKeyPressed,
+	lKeyPressed,
+} from '@/state'
 import {
 	UserPen,
 	Settings2,
@@ -188,6 +202,7 @@ import {
 	Bug,
 	ExternalLink,
 	Repeat,
+	ArrowRightToLine,
 	Shield,
 	Lock,
 } from 'lucide-vue-next'
@@ -203,6 +218,10 @@ const isBugButtonHovered = shallowRef(false)
 function onBugHover(hovered: boolean) {
 	isBugButtonHovered.value = hovered
 }
+
+const { isPlayheadTracking } = defineProps<{
+	isPlayheadTracking: boolean
+}>()
 
 const router = useRouter()
 const inDev = import.meta.env.MODE === 'development'
@@ -230,6 +249,7 @@ const emits = defineEmits<{
 	(e: 'onUndo'): void
 	(e: 'onSendChat'): void
 	(e: 'onToggleLoop'): void
+	(e: 'onTogglePlayheadTracking'): void
 }>()
 
 async function cancelEditingUsername() {

--- a/src/state.ts
+++ b/src/state.ts
@@ -63,6 +63,7 @@ export const controlKeyPressed = shallowRef(false)
 export const shiftKeyPressed = shallowRef(false)
 export const zKeyPressed = shallowRef(false)
 export const tKeyPressed = shallowRef(false)
+export const fKeyPressed = shallowRef(false)
 export const lKeyPressed = shallowRef(false)
 export const rightMouseButtonPressedOnTimeline = shallowRef(false)
 
@@ -100,6 +101,8 @@ useIntervalFn(
 )
 
 useEventListener(window, 'keydown', (event) => {
+	const key = event.key.toLowerCase()
+
 	if (event.key === 'Alt') {
 		altKeyPressed.value = true
 		event.preventDefault()
@@ -116,23 +119,30 @@ useEventListener(window, 'keydown', (event) => {
 		return
 	}
 
-	if (event.key === 'z') {
+	if (key === 'z') {
 		zKeyPressed.value = true
 		return
 	}
 
-	if (event.key === 't') {
+	if (key === 't') {
 		tKeyPressed.value = true
 		return
 	}
 
-	if (event.key === 'l') {
+	if (key === 'f') {
+		fKeyPressed.value = true
+		return
+	}
+
+	if (key === 'l') {
 		lKeyPressed.value = true
 		return
 	}
 })
 
 useEventListener(window, 'keyup', (event) => {
+	const key = event.key.toLowerCase()
+
 	if (event.key === 'Alt') {
 		altKeyPressed.value = false
 		event.preventDefault()
@@ -149,17 +159,22 @@ useEventListener(window, 'keyup', (event) => {
 		return
 	}
 
-	if (event.key === 'z') {
+	if (key === 'z') {
 		zKeyPressed.value = false
 		return
 	}
 
-	if (event.key === 't') {
+	if (key === 't') {
 		tKeyPressed.value = false
 		return
 	}
 
-	if (event.key === 'l') {
+	if (key === 'f') {
+		fKeyPressed.value = false
+		return
+	}
+
+	if (key === 'l') {
 		lKeyPressed.value = false
 		return
 	}

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -28,6 +28,17 @@
 					}"
 				/>
 			</button>
+			<button
+				@click="togglePlayheadTracking"
+				class="controls-panel-btn"
+				:class="{ tracking: isPlayheadTracking }"
+				style="border-left: none"
+				title="Playhead tracking during playback (F)"
+			>
+				<span class="tracking-icon-badge" :class="{ active: isPlayheadTracking }">
+					<ArrowRightToLine :size="14" />
+				</span>
+			</button>
 
 			<p class="small mono controls-panel-wrap">
 				{{ minutesNseconds }}<br />
@@ -115,10 +126,12 @@
 
 			<div v-if="isUserMenuOpen" ref="userMenu" style="z-index: 100" :style="floatingStyles">
 				<UserMenu
+					:is-playhead-tracking="isPlayheadTracking"
 					@on-updated="update()"
 					@on-undo="tryUndo()"
 					@on-send-chat="sendChat()"
 					@on-toggle-loop="toggleLoop()"
+					@on-toggle-playhead-tracking="togglePlayheadTracking()"
 				/>
 			</div>
 		</div>
@@ -242,6 +255,7 @@ import { _socketReady, initializeSocket, socket, socketReadyState } from '@/sock
 import {
 	computed,
 	nextTick,
+	onBeforeUnmount,
 	onMounted,
 	reactive,
 	ref,
@@ -279,6 +293,7 @@ import {
 	useElementBounding,
 } from '@vueuse/core'
 import {
+	currentTime,
 	currentPlayTimeBeats,
 	currentPlayTimeSeconds,
 	isPlaying,
@@ -320,6 +335,7 @@ import {
 	Download,
 	Volume2,
 	ZoomIn,
+	ArrowRightToLine,
 } from 'lucide-vue-next'
 import { offset, useFloating } from '@floating-ui/vue'
 import { useRouter } from 'vue-router'
@@ -475,6 +491,17 @@ useEventListener(window, 'focusin', (e) => {
 })
 
 useEventListener('keydown', (event) => {
+	const target = event.target as HTMLElement | null
+	if (
+		target &&
+		(target.tagName === 'INPUT' ||
+			target.tagName === 'TEXTAREA' ||
+			target.tagName === 'SELECT' ||
+			target.isContentEditable)
+	) {
+		return
+	}
+
 	if (event.code === 'Space') {
 		event.preventDefault()
 		if (isPlaying.value) pause()
@@ -484,6 +511,11 @@ useEventListener('keydown', (event) => {
 	if (event.code === 'KeyL') {
 		toggleLoop()
 	}
+
+	if (event.code === 'KeyF') {
+		event.preventDefault()
+		togglePlayheadTracking()
+	}
 })
 
 function togglePlayState() {
@@ -492,6 +524,87 @@ function togglePlayState() {
 }
 
 const timelineContainerEl = useTemplateRef('timelineContainer')
+const isPlayheadTracking = shallowRef(false)
+const playheadTrackingRafId = shallowRef<number | null>(null)
+const playheadTrackingLastAppliedScrollLeft = shallowRef<number | null>(null)
+const PLAYHEAD_TRACKING_BACKWARD_NOISE_PX = 1.25
+const trackingPlayheadBeat = computed(() => sec_to_beats(currentTime.value))
+
+function snapToDevicePixel(px: number) {
+	const dpr =
+		typeof window !== 'undefined' && window.devicePixelRatio > 0 ? window.devicePixelRatio : 1
+	return Math.round(px * dpr) / dpr
+}
+
+function clampTimelineScrollLeft(scrollLeft: number, container: HTMLElement) {
+	const maxScrollLeft = Math.max(0, container.scrollWidth - container.clientWidth)
+	return Math.max(0, Math.min(maxScrollLeft, scrollLeft))
+}
+
+function getCenteredPlayheadScrollLeft(container: HTMLElement) {
+	const playheadPx = snapToDevicePixel(trackingPlayheadBeat.value * pxPerBeat.value)
+	return clampTimelineScrollLeft(playheadPx - container.clientWidth / 2, container)
+}
+
+function centerPlayheadInViewport() {
+	const container = timelineContainerEl.value
+	if (!container) return
+	const centeredTarget = getCenteredPlayheadScrollLeft(container)
+	container.scrollLeft = centeredTarget
+	playheadTrackingLastAppliedScrollLeft.value = centeredTarget
+}
+
+function followPlayheadInViewport() {
+	const container = timelineContainerEl.value
+	if (!container) return
+
+	const targetScrollLeft = getCenteredPlayheadScrollLeft(container)
+	const previousAppliedScrollLeft = playheadTrackingLastAppliedScrollLeft.value
+	const stableTargetScrollLeft =
+		previousAppliedScrollLeft != null &&
+		targetScrollLeft < previousAppliedScrollLeft &&
+		previousAppliedScrollLeft - targetScrollLeft <= PLAYHEAD_TRACKING_BACKWARD_NOISE_PX
+			? previousAppliedScrollLeft
+			: targetScrollLeft
+
+	container.scrollLeft = stableTargetScrollLeft
+	playheadTrackingLastAppliedScrollLeft.value = container.scrollLeft
+}
+
+function stopPlayheadTrackingAnimation() {
+	if (playheadTrackingRafId.value == null) return
+	cancelAnimationFrame(playheadTrackingRafId.value)
+	playheadTrackingRafId.value = null
+	playheadTrackingLastAppliedScrollLeft.value = null
+}
+
+function runPlayheadTrackingFrame() {
+	if (!isPlayheadTracking.value || !isPlaying.value) {
+		stopPlayheadTrackingAnimation()
+		return
+	}
+
+	followPlayheadInViewport()
+	playheadTrackingRafId.value = requestAnimationFrame(runPlayheadTrackingFrame)
+}
+
+function ensurePlayheadTrackingAnimation() {
+	if (playheadTrackingRafId.value != null) return
+	playheadTrackingRafId.value = requestAnimationFrame(runPlayheadTrackingFrame)
+}
+
+function togglePlayheadTracking() {
+	isPlayheadTracking.value = !isPlayheadTracking.value
+	if (!isPlayheadTracking.value) {
+		stopPlayheadTrackingAnimation()
+		return
+	}
+	if (!isPlaying.value) return
+	nextTick(() => {
+		centerPlayheadInViewport()
+		ensurePlayheadTrackingAnimation()
+	})
+}
 
 useEventListener(
 	timelineContainerEl,
@@ -553,6 +666,25 @@ useEventListener(timelineContainerEl, 'pointerdown', (e) => {
 
 const { x: scrollX, y: scrollY } = useScroll(timelineContainerEl)
 const { width: timelineContainerClientWidth } = useElementSize(timelineContainerEl)
+
+watch(
+	[isPlayheadTracking, isPlaying],
+	([isTracking, playing]) => {
+		if (!isTracking || !playing) {
+			stopPlayheadTrackingAnimation()
+			return
+		}
+		nextTick(() => {
+			centerPlayheadInViewport()
+			ensurePlayheadTrackingAnimation()
+		})
+	},
+	{ immediate: true },
+)
+
+onBeforeUnmount(() => {
+	stopPlayheadTrackingAnimation()
+})
 
 async function handleTrackAdded() {
 	await nextTick() // awaiting repaint
@@ -1211,6 +1343,33 @@ useEventListener(window, 'blur', () => {
 	align-content: center;
 	line-height: 1.06em;
 	border-right: 1px solid var(--border-primary);
+}
+
+.controls-panel-btn.tracking {
+	box-shadow:
+		0px 0px 24px -12px hsl(var(--active-looping-hue) 100% 50% / 0.75),
+		inset 0px 0px 8px -5px hsl(var(--active-looping-hue) 100% 50% / 0.8);
+}
+
+.tracking-icon-badge {
+	width: 1.7rem;
+	height: 1.7rem;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 0.2rem;
+	background-color: transparent;
+	color: var(--text-color-primary);
+	transition:
+		background-color 120ms ease,
+		color 120ms ease,
+		box-shadow 120ms ease;
+}
+
+.tracking-icon-badge.active {
+	background-color: hsl(var(--active-looping-hue) 100% 58% / 0.95);
+	color: hsl(0 0% 12% / 1);
+	box-shadow: inset 0 0 0 1px hsl(var(--active-looping-hue) 100% 30% / 0.8);
 }
 
 .open-user-menu-btn {


### PR DESCRIPTION
## Summary

This PR adds **Playhead Tracking** with centered auto-scroll.

### Changes

- New transport button (next to Loop) to toggle tracking
- New shortcut: **`F`** (keeps `T` for existing usage)
- New **User Menu** entry: `Enable/Disable Tracking` + `F` indicator
- Tracking runs **only while playback is active**

### Result

We followed the usual project recommendations/style, and fixed the tracking behavior so it is now **jitter-free** with the playhead centered, even at high zoom.

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run format`
- pre-commit checks passed

Closes #78 
